### PR TITLE
Upgrade golang version to 1.11.5

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,13 +3,13 @@ gardenctl:
   base_definition:
     repo: ~
     traits:
-      version: 
+      version:
         inject_effective_version: true
     steps:
       test:
-        image: 'golang:1.11.0'
+        image: 'golang:1.11.5'
       build:
-        image: 'golang:1.11.0'
+        image: 'golang:1.11.5'
   variants:
     head-update: ~
     pull-request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build gardenctl binary
-FROM golang:1.10
+FROM golang:1.11.5
 RUN mkdir -p /go/src/github.com/gardener/gardenctl &&\
     cd /go/src/github.com/gardener &&\
     git clone https://github.com/gardener/gardenctl.git &&\
@@ -44,7 +44,7 @@ RUN apt-get --yes update;\
     curl -sL https://github.com/jingweno/ccat/releases/download/v1.1.0/linux-amd64-1.1.0.tar.gz -o ccat.tar.gz && tar -zxvf ccat.tar.gz linux-amd64-1.1.0/ccat && mv linux-amd64-1.1.0/ccat /bin/cat && rm -rf linux-amd64-1.1.0 ccat.tar.gz && chmod 755 /bin/cat;\
     curl -sL http://stedolan.github.io/jq/download/linux64/jq -o /bin/jq && chmod 755 /bin/jq;\
     curl -sL https://github.com/bronze1man/yaml2json/raw/master/builds/linux_amd64/yaml2json -o /bin/yaml2json && chmod 755 /bin/yaml2json;\
-# remove package lists to safe space
+    # remove package lists to safe space
     rm -rf /var/lib/apt/lists
 
 # install network tools
@@ -55,7 +55,7 @@ RUN apt-get --yes update;\
     apt-get --yes install dstat;\
     apt-get --yes install ngrep;\
     apt-get --yes install tcpdump;\
-# remove package lists to safe space
+    # remove package lists to safe space
     rm -rf /var/lib/apt/lists
 
 # install Kubernetes CLI
@@ -81,7 +81,7 @@ RUN apt-get --yes update;\
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -;\
     apt-get --yes update && apt-get --yes install azure-cli;\
     apt-get --yes --purge remove lsb-release gnupg apt-transport-https;\
-# remove package lists to safe space
+    # remove package lists to safe space
     rm -rf /var/lib/apt/lists
 
 # install GCP CLI
@@ -92,7 +92,7 @@ RUN apt-get --yes update;\
     curl -sL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -;\
     apt-get --yes update && apt-get --yes install google-cloud-sdk;\
     apt-get --yes --purge remove lsb-release gnupg apt-transport-https;\
-# remove package lists to safe space
+    # remove package lists to safe space
     rm -rf /var/lib/apt/lists
 
 # install OpenStack CLI


### PR DESCRIPTION
**What this PR does / why we need it**:

> We have just released Go 1.11.5 and Go 1.10.8 to address a recently reported security issue. We recommend that all users update to one of these releases (if you’re not sure which, choose Go 1.11.5).
>
> This DoS vulnerability in the crypto/elliptic implementations of the P-521 and P-384 elliptic curves may let an attacker craft inputs that consume excessive amounts of CPU.
>
> These inputs might be delivered via TLS handshakes, X.509 certificates, JWT tokens, ECDH shares or ECDSA signatures. In some cases, if an ECDH private key is reused more than once, the attack can also lead to key recovery.
>
> The issue is CVE-2019-6486.


**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

n/a

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```

/cc @ThormaehlenFred