### PR TITLE
Prevent function name collision in completion script

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ __gardenctl_parse() {
 	esac
 }
 
-__custom_func() {
+__gardenctl_custom_func() {
 	case ${last_command} in
 	gardenctl_target | gardenctl_get)
 	if [[ ${#nouns[@]} -ne 0 ]]; then


### PR DESCRIPTION
Follow up on #57

The `kubectl` defines `__custom_func` as well as the `gardenctl`. As result, the latest sourced completion file overwrite the already defined `__custom_func` func.

See [the example here](https://github.com/spf13/cobra/blob/master/bash_completions.md#creating-your-own-custom-functions)

