### PR TITLE
Update golang to 1.12.0

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,11 +7,11 @@ gardenctl:
         inject_effective_version: true
     steps:
       check:
-        image: 'golang:1.11.5'
+        image: 'golang:1.12.0'
       test:
-        image: 'golang:1.11.5'
+        image: 'golang:1.12.0'
       build:
-        image: 'golang:1.11.5'
+        image: 'golang:1.12.0'
   variants:
     head-update: ~
     pull-request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build gardenctl binary
-FROM golang:1.11.5
+FROM golang:1.12.0
 RUN mkdir -p /go/src/github.com/gardener/gardenctl &&\
     cd /go/src/github.com/gardener &&\
     git clone https://github.com/gardener/gardenctl.git &&\


### PR DESCRIPTION
**What this PR does / why we need it**:
https://golang.org/doc/go1.12

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The golang version has been upgraded to `v1.12.0`.
```
