### PR TITLE
Add PR template, enable draft releases, post to slack

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -13,7 +13,9 @@ gardenctl:
       build:
         image: 'golang:1.12.0'
   variants:
-    head-update: ~
+    head-update:
+      traits:
+        draft_release: ~
     pull-request:
       traits:
         pull-request: ~
@@ -23,3 +25,9 @@ gardenctl:
           preprocess: 'finalize'
         release:
           release_callback: './.ci/update_latest_version'
+        slack:
+          default_channel: 'internal_scp_workspace'
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: 'k8s-op-of-the-week'
+              slack_cfg_name: 'scp_workspace'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Release note**:
+<!--  Write your release note:
+1. Enter your release note in the below block.
+2. If no release note is required, just write "NONE" within the block.
+
+Format of block header: <category> <target_group>
+Possible values:
+- category:       improvement|noteworthy|action
+- target_group:   user|operator
+-->
+```improvement operator
+
+```


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds PR template
- Enables draft releases
- Posts release notes to internal slack channel

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.
Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```