### PR TITLE
Improve shell command

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -112,6 +112,9 @@ func shellToNode(name string) {
 	manifest = strings.Replace(manifest, "HOSTNAME", hostname, -1)
 	err = ExecCmd([]byte(manifest), "kubectl -n "+namespace+" apply -f -", false, "KUBECONFIG="+getKubeConfigOfClusterType(typeName))
 	checkError(err)
+
+	Client, err = clientToTarget(typeName)
+	checkError(err)
 	for true {
 		pod, err := Client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
`gardenctl shell <node>` fails with
```
pod/rootpod-<user> created
pod not found: pods "rootpod-<user>" not found
pod not found: pods "rootpod-<user>" not found
pod not found: pods "rootpod-<user>" not found
[...]
```
when the second target in the target stack is seed.

Work in progress, unit tests to be added.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
`gardenctl shell <node>` now properly handles cases when the second target in the target stack is seed.
```
