### PR TITLE
integrate aliyun cli with gardenctl

### DIFF
--- a/cmd/aliyun.go
+++ b/cmd/aliyun.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// aliyunCmd represents the aliyun command
+var aliyunCmd = &cobra.Command{
+	Use:   "aliyun <args>",
+	Short: "",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		var t Target
+		targetFile, err := ioutil.ReadFile(pathTarget)
+		checkError(err)
+		err = yaml.Unmarshal(targetFile, &t)
+		checkError(err)
+		if len(t.Target) < 3 {
+			fmt.Println("No shoot targeted")
+			os.Exit(2)
+		}
+		arguments := "aliyun " + strings.Join(args[:], " ")
+		operate("aliyun", arguments)
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,7 +125,7 @@ func init() {
 	RootCmd.AddCommand(completionCmd)
 	RootCmd.AddCommand(shellCmd)
 	RootCmd.AddCommand(sshCmd)
-	RootCmd.AddCommand(kubectlCmd, kaCmd, ksCmd, kgCmd, knCmd, awsCmd, azCmd, gcloudCmd, openstackCmd)
+	RootCmd.AddCommand(kubectlCmd, kaCmd, ksCmd, kgCmd, knCmd, awsCmd, azCmd, gcloudCmd, openstackCmd, aliyunCmd)
 	RootCmd.AddCommand(infoCmd)
 	RootCmd.AddCommand(versionCmd)
 	RootCmd.SuggestionsMinimumDistance = suggestionsMinimumDistance


### PR DESCRIPTION
**What this PR does / why we need it**:
Integrate aliyun infrastructure cli with gardenctl.

**Which issue(s) this PR fixes**:
Fixes #68 

**Special notes for your reviewer**:
cc Jerry, Minchao

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
'gardenctl aliyun <args>' is now available on alicloud clusters.
```
