### PR TITLE
Add TargetKind type

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -630,7 +630,7 @@
   version = "kubernetes-1.14.0"
 
 [[projects]]
-  digest = "1:c0f19f368bcf05fd68dc0390a5d930897a2f7c73fbed995edc631c4664e72e4e"
+  digest = "1:8b5ebdb22b5f2a8d2a241a5c9dfe977aee6f5e0468c4712da72c9d114ccd97b9"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -667,6 +667,7 @@
     "pkg/util/strategicpatch",
     "pkg/util/validation",
     "pkg/util/validation/field",
+    "pkg/util/wait",
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
@@ -837,7 +838,9 @@
     "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/plugin/pkg/client/auth/azure",

--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd_test
 
 import (

--- a/cmd/drop.go
+++ b/cmd/drop.go
@@ -37,11 +37,11 @@ var dropCmd = &cobra.Command{
 			var target Target
 			ReadTarget(pathTarget, &target)
 			if len(target.Target) == 1 {
-				fmt.Println("Dropped " + target.Target[0].Kind + " " + target.Target[0].Name)
+				fmt.Printf("Dropped %s %s\n", target.Target[0].Kind, target.Target[0].Name)
 			} else if len(target.Target) == 2 {
-				fmt.Println("Dropped " + target.Target[1].Kind + " " + target.Target[1].Name)
+				fmt.Printf("Dropped %s %s\n", target.Target[1].Kind, target.Target[1].Name)
 			} else if len(target.Target) == 3 {
-				fmt.Println("Dropped " + target.Target[2].Kind + " " + target.Target[2].Name)
+				fmt.Printf("Dropped %s %s\n", target.Target[2].Kind, target.Target[2].Name)
 			}
 			drop()
 		} else if len(args) == 1 {
@@ -51,24 +51,24 @@ var dropCmd = &cobra.Command{
 			case "project":
 				if len(target.Target) == 2 && target.Target[1].Kind == "project" {
 					drop()
-					fmt.Println("Dropped " + target.Target[1].Kind + " " + target.Target[1].Name)
+					fmt.Printf("Dropped %s %s\n", target.Target[1].Kind, target.Target[1].Name)
 				} else if len(target.Target) == 3 && target.Target[1].Kind == "project" {
 					drop()
 					drop()
-					fmt.Println("Dropped " + target.Target[2].Kind + " " + target.Target[2].Name)
-					fmt.Println("Dropped " + target.Target[1].Kind + " " + target.Target[1].Name)
+					fmt.Printf("Dropped %s %s\n", target.Target[2].Kind, target.Target[2].Name)
+					fmt.Printf("Dropped %s %s\n", target.Target[1].Kind, target.Target[1].Name)
 				} else {
 					fmt.Println("A seed is targeted")
 				}
 			case "seed":
 				if len(target.Target) == 2 && target.Target[1].Kind == "seed" {
 					drop()
-					fmt.Println("Dropped " + target.Target[1].Kind + " " + target.Target[1].Name)
+					fmt.Printf("Dropped %s %s\n", target.Target[1].Kind, target.Target[1].Name)
 				} else if len(target.Target) == 3 && target.Target[1].Kind == "seed" {
 					drop()
 					drop()
-					fmt.Println("Dropped " + target.Target[2].Kind + " " + target.Target[2].Name)
-					fmt.Println("Dropped " + target.Target[1].Kind + " " + target.Target[1].Name)
+					fmt.Printf("Dropped %s %s\n", target.Target[2].Kind, target.Target[2].Name)
+					fmt.Printf("Dropped %s %s\n", target.Target[1].Kind, target.Target[1].Name)
 				} else {
 					fmt.Println("A project is targeted")
 				}
@@ -78,9 +78,6 @@ var dropCmd = &cobra.Command{
 		}
 	},
 	ValidArgs: []string{"project", "seed"},
-}
-
-func init() {
 }
 
 // drop drops target until stack is empty

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -185,7 +185,7 @@ func logPod(toMatch string, toTarget string, container string) {
 	checkError(err)
 	if toTarget == "shoot" {
 		namespace = "kube-system"
-		Client, err = clientToTarget(toTarget)
+		Client, err = clientToTarget(TargetKindShoot)
 		checkError(err)
 	}
 	if !flags.elasticsearch {

--- a/cmd/miscellaneous.go
+++ b/cmd/miscellaneous.go
@@ -71,20 +71,19 @@ func GetGardenClusterKubeConfigFromConfig(pathGardenConfig, pathTarget string) {
 }
 
 // clientToTarget returns the client to target e.g. garden, seed
-func clientToTarget(target string) (*k8s.Clientset, error) {
-	// TODO (ialidzhikov): move the invocations to the corresponding method in TargetProviderAPI
+func clientToTarget(target TargetKind) (*k8s.Clientset, error) {
 	switch target {
-	case "garden":
+	case TargetKindGarden:
 		KUBECONFIG = getKubeConfigOfClusterType("garden")
-	case "seed":
+	case TargetKindSeed:
 		KUBECONFIG = getKubeConfigOfClusterType("seed")
-	case "shoot":
+	case TargetKindShoot:
 		KUBECONFIG = getKubeConfigOfClusterType("shoot")
 	}
 	var pathToKubeconfig = ""
 	if kubeconfig == nil {
 		if home := HomeDir(); home != "" {
-			if target == "seed" || target == "shoot" {
+			if target == TargetKindSeed || target == TargetKindShoot {
 				kubeconfig = flag.String("kubeconfig", getKubeConfigOfCurrentTarget(), "(optional) absolute path to the kubeconfig file")
 			} else {
 				if strings.Contains(getGardenKubeConfig(), "~") {
@@ -229,22 +228,21 @@ func getProjectForShoot() (projectName string) {
 }
 
 // getTargetType returns error and name of type
-func getTargetType() (string, error) {
-	// TODO (ialidzhikov): move the invocations to the corresponding method in TargetProviderAPI
+func getTargetType() (TargetKind, error) {
 	var target Target
 	ReadTarget(pathTarget, &target)
 	length := len(target.Target)
 	switch length {
 	case 1:
-		return "garden", nil
+		return TargetKindGarden, nil
 	case 2:
 		if target.Target[1].Kind == "seed" {
-			return "seed", nil
+			return TargetKindSeed, nil
 		}
 
-		return "project", nil
+		return TargetKindProject, nil
 	case 3:
-		return "shoot", nil
+		return TargetKindShoot, nil
 	default:
 		return "", errors.New("No target selected")
 	}

--- a/cmd/miscellaneous_test.go
+++ b/cmd/miscellaneous_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd_test
 
 import (

--- a/cmd/mocks.go
+++ b/cmd/mocks.go
@@ -34,7 +34,7 @@ func (m *MockTargetProviderAPI) EXPECT() *MockTargetProviderAPIMockRecorder {
 }
 
 // ClientToTarget mocks base method
-func (m *MockTargetProviderAPI) ClientToTarget(arg0 string) (kubernetes.Interface, error) {
+func (m *MockTargetProviderAPI) ClientToTarget(arg0 TargetKind) (kubernetes.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClientToTarget", arg0)
 	ret0, _ := ret[0].(kubernetes.Interface)
@@ -49,10 +49,10 @@ func (mr *MockTargetProviderAPIMockRecorder) ClientToTarget(arg0 interface{}) *g
 }
 
 // FetchTargetKind mocks base method
-func (m *MockTargetProviderAPI) FetchTargetKind() (string, error) {
+func (m *MockTargetProviderAPI) FetchTargetKind() (TargetKind, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchTargetKind")
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(TargetKind)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -56,8 +56,8 @@ var _ = Describe("Shell command", func() {
 					Name: "minikube",
 				},
 			})
-			tp.EXPECT().FetchTargetKind().Return("shoot", nil)
-			tp.EXPECT().ClientToTarget(gomock.Eq("shoot")).Return(clientSet, nil)
+			tp.EXPECT().FetchTargetKind().Return(cmd.TargetKindShoot, nil)
+			tp.EXPECT().ClientToTarget(gomock.Eq(cmd.TargetKindShoot)).Return(clientSet, nil)
 
 			ioStreams, _, out, _ := cmd.NewTestIOStreams()
 			command = cmd.NewShellCmd(tp, ioStreams)
@@ -69,7 +69,7 @@ var _ = Describe("Shell command", func() {
 
 		Context("when project is targeted", func() {
 			It("should return error", func() {
-				tp.EXPECT().FetchTargetKind().Return("project", nil)
+				tp.EXPECT().FetchTargetKind().Return(cmd.TargetKindProject, nil)
 
 				ioStreams, _, _, _ := cmd.NewTestIOStreams()
 				command = cmd.NewShellCmd(tp, ioStreams)
@@ -84,8 +84,8 @@ var _ = Describe("Shell command", func() {
 	Context("with non-existing node name", func() {
 		It("should return error", func() {
 			clientSet = fake.NewSimpleClientset()
-			tp.EXPECT().FetchTargetKind().Return("shoot", nil)
-			tp.EXPECT().ClientToTarget(gomock.Eq("shoot")).Return(clientSet, nil)
+			tp.EXPECT().FetchTargetKind().Return(cmd.TargetKindShoot, nil)
+			tp.EXPECT().ClientToTarget(gomock.Eq(cmd.TargetKindShoot)).Return(clientSet, nil)
 
 			ioStreams, _, _, _ := cmd.NewTestIOStreams()
 			command = cmd.NewShellCmd(tp, ioStreams)
@@ -98,7 +98,7 @@ var _ = Describe("Shell command", func() {
 
 	Context("when project is targeted", func() {
 		It("should return error", func() {
-			tp.EXPECT().FetchTargetKind().Return("project", nil)
+			tp.EXPECT().FetchTargetKind().Return(cmd.TargetKindProject, nil)
 
 			ioStreams, _, _, _ := cmd.NewTestIOStreams()
 			command = cmd.NewShellCmd(tp, ioStreams)

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -170,7 +170,7 @@ func showGardenerDashboard() {
 }
 
 // showPod is an abstraction to show pods in seed cluster controlplane or kube-system namespace of shoot
-func showPod(toMatch string, toTarget string) {
+func showPod(toMatch string, toTarget TargetKind) {
 	var target Target
 	ReadTarget(pathTarget, &target)
 
@@ -183,9 +183,9 @@ func showPod(toMatch string, toTarget string) {
 
 	Client, err = clientToTarget("seed")
 	checkError(err)
-	if toTarget == "shoot" {
+	if toTarget == TargetKindShoot {
 		namespace = "kube-system"
-		Client, err = clientToTarget(toTarget)
+		Client, err = clientToTarget(TargetKindShoot)
 		checkError(err)
 	}
 	pods, err := Client.CoreV1().Pods(namespace).List(metav1.ListOptions{})

--- a/cmd/target.go
+++ b/cmd/target.go
@@ -619,23 +619,23 @@ func getSeedForProject(shootName string) (seedName string) {
 }
 
 // getKubeConfigOfClusterType return config of specified type
-func getKubeConfigOfClusterType(clusterType string) (pathToKubeconfig string) {
+func getKubeConfigOfClusterType(clusterType TargetKind) (pathToKubeconfig string) {
 	var target Target
 	ReadTarget(pathTarget, &target)
 	switch clusterType {
-	case "garden":
+	case TargetKindGarden:
 		if strings.Contains(getGardenKubeConfig(), "~") {
 			pathToKubeconfig = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(getGardenKubeConfig(), "~", "", 1)))
 		} else {
 			pathToKubeconfig = getGardenKubeConfig()
 		}
-	case "seed":
+	case TargetKindSeed:
 		if target.Target[1].Kind == "seed" {
 			pathToKubeconfig = pathGardenHome + "/cache/seeds" + "/" + target.Target[1].Name + "/" + "kubeconfig.yaml"
 		} else {
 			pathToKubeconfig = pathGardenHome + "/cache/seeds" + "/" + getSeedForProject(target.Target[2].Name) + "/" + "kubeconfig.yaml"
 		}
-	case "shoot":
+	case TargetKindShoot:
 		if target.Target[1].Kind == "seed" {
 			pathToKubeconfig = pathGardenHome + "/cache/seeds" + "/" + getSeedForProject(target.Target[2].Name) + "/" + target.Target[2].Name + "/" + "kubeconfig.yaml"
 		} else if target.Target[1].Kind == "project" {

--- a/cmd/target_provider.go
+++ b/cmd/target_provider.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes"
 )
 
 // NewTargetProvider returns a new target provider.
@@ -24,11 +24,11 @@ func NewTargetProvider() *TargetProvider {
 }
 
 // FetchTargetKind returns the current target kind.
-func (tp *TargetProvider) FetchTargetKind() (string, error) {
+func (tp *TargetProvider) FetchTargetKind() (TargetKind, error) {
 	return getTargetType()
 }
 
 // ClientToTarget returns a kubernetes client configured against the current target.
-func (tp *TargetProvider) ClientToTarget(target string) (k8s.Interface, error) {
-	return clientToTarget(target)
+func (tp *TargetProvider) ClientToTarget(targetKind TargetKind) (kubernetes.Interface, error) {
+	return clientToTarget(targetKind)
 }

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -14,12 +14,12 @@
 
 package cmd
 
-import k8s "k8s.io/client-go/kubernetes"
+import "k8s.io/client-go/kubernetes"
 
 // TargetProviderAPI provides bindings for target operations.
 type TargetProviderAPI interface {
-	FetchTargetKind() (string, error)
-	ClientToTarget(target string) (k8s.Interface, error)
+	FetchTargetKind() (TargetKind, error)
+	ClientToTarget(target TargetKind) (kubernetes.Interface, error)
 }
 
 // TargetProvider implements TargetProviderAPI.
@@ -30,10 +30,25 @@ type Target struct {
 	Target []TargetMeta `yaml:"target,omitempty" json:"target,omitempty"`
 }
 
-// TargetMeta contains kind and name of target
+// TargetKind is a valid value for target kind.
+type TargetKind string
+
+// These are valid target kinds.
+const (
+	// TargetKindGarden points to garden cluster.
+	TargetKindGarden TargetKind = "garden"
+	// TargetKindProject points to project.
+	TargetKindProject TargetKind = "project"
+	// TargetKindSeed points to seed cluster.
+	TargetKindSeed TargetKind = "seed"
+	// TargetKindShoot points to shoot cluster.
+	TargetKindShoot TargetKind = "shoot"
+)
+
+// TargetMeta contains kind and name of target.
 type TargetMeta struct {
-	Kind string `yaml:"kind,omitempty" json:"kind,omitempty"`
-	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+	Kind TargetKind `yaml:"kind,omitempty" json:"kind,omitempty"`
+	Name string     `yaml:"name,omitempty" json:"name,omitempty"`
 }
 
 // Projects contains list of all projects

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -35,13 +35,13 @@ var _ = Describe("Utils", func() {
 	pathFile := dumpPath + "/testDir/testfile"
 	pathTarget := dumpPath + "/target"
 	tm.Name = "garden-test"
-	tm.Kind = "garden"
+	tm.Kind = TargetKindGarden
 	target.Target = append(target.Target, tm)
 	tm.Name = "seed-test"
-	tm.Kind = "seed"
+	tm.Kind = TargetKindSeed
 	target.Target = append(target.Target, tm)
 	tm.Name = "shoot-test"
-	tm.Kind = "shoot"
+	tm.Kind = TargetKindShoot
 	target.Target = append(target.Target, tm)
 
 	file, err := os.OpenFile(pathTarget, os.O_WRONLY|os.O_CREATE, 0644)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -37,9 +37,6 @@ var versionCmd = &cobra.Command{
 	go version  : %s
 	go compiler : %s
 	platform    : %s/%s
-	   `, version, buildDate, runtime.Version(), runtime.Compiler, runtime.GOOS, runtime.GOARCH)
+`, version, buildDate, runtime.Version(), runtime.Compiler, runtime.GOOS, runtime.GOARCH)
 	},
-}
-
-func init() {
 }

--- a/vendor/k8s.io/apimachinery/pkg/util/wait/doc.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/wait/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package wait provides tools for polling or listening for changes
+// to a condition.
+package wait // import "k8s.io/apimachinery/pkg/util/wait"

--- a/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -1,0 +1,481 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// For any test of the style:
+//   ...
+//   <- time.After(timeout):
+//      t.Errorf("Timed out")
+// The value for timeout should effectively be "forever." Obviously we don't want our tests to truly lock up forever, but 30s
+// is long enough that it is effectively forever for the things that can slow down a run on a heavily contended machine
+// (GC, seeks, etc), but not so long as to make a developer ctrl-c a test run if they do happen to break that test.
+var ForeverTestTimeout = time.Second * 30
+
+// NeverStop may be passed to Until to make it never stop.
+var NeverStop <-chan struct{} = make(chan struct{})
+
+// Group allows to start a group of goroutines and wait for their completion.
+type Group struct {
+	wg sync.WaitGroup
+}
+
+func (g *Group) Wait() {
+	g.wg.Wait()
+}
+
+// StartWithChannel starts f in a new goroutine in the group.
+// stopCh is passed to f as an argument. f should stop when stopCh is available.
+func (g *Group) StartWithChannel(stopCh <-chan struct{}, f func(stopCh <-chan struct{})) {
+	g.Start(func() {
+		f(stopCh)
+	})
+}
+
+// StartWithContext starts f in a new goroutine in the group.
+// ctx is passed to f as an argument. f should stop when ctx.Done() is available.
+func (g *Group) StartWithContext(ctx context.Context, f func(context.Context)) {
+	g.Start(func() {
+		f(ctx)
+	})
+}
+
+// Start starts f in a new goroutine in the group.
+func (g *Group) Start(f func()) {
+	g.wg.Add(1)
+	go func() {
+		defer g.wg.Done()
+		f()
+	}()
+}
+
+// Forever calls f every period for ever.
+//
+// Forever is syntactic sugar on top of Until.
+func Forever(f func(), period time.Duration) {
+	Until(f, period, NeverStop)
+}
+
+// Until loops until stop channel is closed, running f every period.
+//
+// Until is syntactic sugar on top of JitterUntil with zero jitter factor and
+// with sliding = true (which means the timer for period starts after the f
+// completes).
+func Until(f func(), period time.Duration, stopCh <-chan struct{}) {
+	JitterUntil(f, period, 0.0, true, stopCh)
+}
+
+// UntilWithContext loops until context is done, running f every period.
+//
+// UntilWithContext is syntactic sugar on top of JitterUntilWithContext
+// with zero jitter factor and with sliding = true (which means the timer
+// for period starts after the f completes).
+func UntilWithContext(ctx context.Context, f func(context.Context), period time.Duration) {
+	JitterUntilWithContext(ctx, f, period, 0.0, true)
+}
+
+// NonSlidingUntil loops until stop channel is closed, running f every
+// period.
+//
+// NonSlidingUntil is syntactic sugar on top of JitterUntil with zero jitter
+// factor, with sliding = false (meaning the timer for period starts at the same
+// time as the function starts).
+func NonSlidingUntil(f func(), period time.Duration, stopCh <-chan struct{}) {
+	JitterUntil(f, period, 0.0, false, stopCh)
+}
+
+// NonSlidingUntilWithContext loops until context is done, running f every
+// period.
+//
+// NonSlidingUntilWithContext is syntactic sugar on top of JitterUntilWithContext
+// with zero jitter factor, with sliding = false (meaning the timer for period
+// starts at the same time as the function starts).
+func NonSlidingUntilWithContext(ctx context.Context, f func(context.Context), period time.Duration) {
+	JitterUntilWithContext(ctx, f, period, 0.0, false)
+}
+
+// JitterUntil loops until stop channel is closed, running f every period.
+//
+// If jitterFactor is positive, the period is jittered before every run of f.
+// If jitterFactor is not positive, the period is unchanged and not jittered.
+//
+// If sliding is true, the period is computed after f runs. If it is false then
+// period includes the runtime for f.
+//
+// Close stopCh to stop. f may not be invoked if stop channel is already
+// closed. Pass NeverStop to if you don't want it stop.
+func JitterUntil(f func(), period time.Duration, jitterFactor float64, sliding bool, stopCh <-chan struct{}) {
+	var t *time.Timer
+	var sawTimeout bool
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+
+		jitteredPeriod := period
+		if jitterFactor > 0.0 {
+			jitteredPeriod = Jitter(period, jitterFactor)
+		}
+
+		if !sliding {
+			t = resetOrReuseTimer(t, jitteredPeriod, sawTimeout)
+		}
+
+		func() {
+			defer runtime.HandleCrash()
+			f()
+		}()
+
+		if sliding {
+			t = resetOrReuseTimer(t, jitteredPeriod, sawTimeout)
+		}
+
+		// NOTE: b/c there is no priority selection in golang
+		// it is possible for this to race, meaning we could
+		// trigger t.C and stopCh, and t.C select falls through.
+		// In order to mitigate we re-check stopCh at the beginning
+		// of every loop to prevent extra executions of f().
+		select {
+		case <-stopCh:
+			return
+		case <-t.C:
+			sawTimeout = true
+		}
+	}
+}
+
+// JitterUntilWithContext loops until context is done, running f every period.
+//
+// If jitterFactor is positive, the period is jittered before every run of f.
+// If jitterFactor is not positive, the period is unchanged and not jittered.
+//
+// If sliding is true, the period is computed after f runs. If it is false then
+// period includes the runtime for f.
+//
+// Cancel context to stop. f may not be invoked if context is already expired.
+func JitterUntilWithContext(ctx context.Context, f func(context.Context), period time.Duration, jitterFactor float64, sliding bool) {
+	JitterUntil(func() { f(ctx) }, period, jitterFactor, sliding, ctx.Done())
+}
+
+// Jitter returns a time.Duration between duration and duration + maxFactor *
+// duration.
+//
+// This allows clients to avoid converging on periodic behavior. If maxFactor
+// is 0.0, a suggested default value will be chosen.
+func Jitter(duration time.Duration, maxFactor float64) time.Duration {
+	if maxFactor <= 0.0 {
+		maxFactor = 1.0
+	}
+	wait := duration + time.Duration(rand.Float64()*maxFactor*float64(duration))
+	return wait
+}
+
+// ErrWaitTimeout is returned when the condition exited without success.
+var ErrWaitTimeout = errors.New("timed out waiting for the condition")
+
+// ConditionFunc returns true if the condition is satisfied, or an error
+// if the loop should be aborted.
+type ConditionFunc func() (done bool, err error)
+
+// Backoff holds parameters applied to a Backoff function.
+type Backoff struct {
+	// The initial duration.
+	Duration time.Duration
+	// Duration is multiplied by factor each iteration. Must be greater
+	// than or equal to zero.
+	Factor float64
+	// The amount of jitter applied each iteration. Jitter is applied after
+	// cap.
+	Jitter float64
+	// The number of steps before duration stops changing. If zero, initial
+	// duration is always used. Used for exponential backoff in combination
+	// with Factor.
+	Steps int
+	// The returned duration will never be greater than cap *before* jitter
+	// is applied. The actual maximum cap is `cap * (1.0 + jitter)`.
+	Cap time.Duration
+}
+
+// Step returns the next interval in the exponential backoff. This method
+// will mutate the provided backoff.
+func (b *Backoff) Step() time.Duration {
+	if b.Steps < 1 {
+		if b.Jitter > 0 {
+			return Jitter(b.Duration, b.Jitter)
+		}
+		return b.Duration
+	}
+	b.Steps--
+
+	duration := b.Duration
+
+	// calculate the next step
+	if b.Factor != 0 {
+		b.Duration = time.Duration(float64(b.Duration) * b.Factor)
+		if b.Cap > 0 && b.Duration > b.Cap {
+			b.Duration = b.Cap
+			b.Steps = 0
+		}
+	}
+
+	if b.Jitter > 0 {
+		duration = Jitter(duration, b.Jitter)
+	}
+	return duration
+}
+
+// ExponentialBackoff repeats a condition check with exponential backoff.
+//
+// It checks the condition up to Steps times, increasing the wait by multiplying
+// the previous duration by Factor.
+//
+// If Jitter is greater than zero, a random amount of each duration is added
+// (between duration and duration*(1+jitter)).
+//
+// If the condition never returns true, ErrWaitTimeout is returned. All other
+// errors terminate immediately.
+func ExponentialBackoff(backoff Backoff, condition ConditionFunc) error {
+	for backoff.Steps > 0 {
+		if ok, err := condition(); err != nil || ok {
+			return err
+		}
+		if backoff.Steps == 1 {
+			break
+		}
+		time.Sleep(backoff.Step())
+	}
+	return ErrWaitTimeout
+}
+
+// Poll tries a condition func until it returns true, an error, or the timeout
+// is reached.
+//
+// Poll always waits the interval before the run of 'condition'.
+// 'condition' will always be invoked at least once.
+//
+// Some intervals may be missed if the condition takes too long or the time
+// window is too short.
+//
+// If you want to Poll something forever, see PollInfinite.
+func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
+	return pollInternal(poller(interval, timeout), condition)
+}
+
+func pollInternal(wait WaitFunc, condition ConditionFunc) error {
+	done := make(chan struct{})
+	defer close(done)
+	return WaitFor(wait, condition, done)
+}
+
+// PollImmediate tries a condition func until it returns true, an error, or the timeout
+// is reached.
+//
+// PollImmediate always checks 'condition' before waiting for the interval. 'condition'
+// will always be invoked at least once.
+//
+// Some intervals may be missed if the condition takes too long or the time
+// window is too short.
+//
+// If you want to immediately Poll something forever, see PollImmediateInfinite.
+func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) error {
+	return pollImmediateInternal(poller(interval, timeout), condition)
+}
+
+func pollImmediateInternal(wait WaitFunc, condition ConditionFunc) error {
+	done, err := condition()
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+	return pollInternal(wait, condition)
+}
+
+// PollInfinite tries a condition func until it returns true or an error
+//
+// PollInfinite always waits the interval before the run of 'condition'.
+//
+// Some intervals may be missed if the condition takes too long or the time
+// window is too short.
+func PollInfinite(interval time.Duration, condition ConditionFunc) error {
+	done := make(chan struct{})
+	defer close(done)
+	return PollUntil(interval, condition, done)
+}
+
+// PollImmediateInfinite tries a condition func until it returns true or an error
+//
+// PollImmediateInfinite runs the 'condition' before waiting for the interval.
+//
+// Some intervals may be missed if the condition takes too long or the time
+// window is too short.
+func PollImmediateInfinite(interval time.Duration, condition ConditionFunc) error {
+	done, err := condition()
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+	return PollInfinite(interval, condition)
+}
+
+// PollUntil tries a condition func until it returns true, an error or stopCh is
+// closed.
+//
+// PollUntil always waits interval before the first run of 'condition'.
+// 'condition' will always be invoked at least once.
+func PollUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
+	return WaitFor(poller(interval, 0), condition, stopCh)
+}
+
+// PollImmediateUntil tries a condition func until it returns true, an error or stopCh is closed.
+//
+// PollImmediateUntil runs the 'condition' before waiting for the interval.
+// 'condition' will always be invoked at least once.
+func PollImmediateUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
+	done, err := condition()
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+	select {
+	case <-stopCh:
+		return ErrWaitTimeout
+	default:
+		return PollUntil(interval, condition, stopCh)
+	}
+}
+
+// WaitFunc creates a channel that receives an item every time a test
+// should be executed and is closed when the last test should be invoked.
+type WaitFunc func(done <-chan struct{}) <-chan struct{}
+
+// WaitFor continually checks 'fn' as driven by 'wait'.
+//
+// WaitFor gets a channel from 'wait()'', and then invokes 'fn' once for every value
+// placed on the channel and once more when the channel is closed. If the channel is closed
+// and 'fn' returns false without error, WaitFor returns ErrWaitTimeout.
+//
+// If 'fn' returns an error the loop ends and that error is returned. If
+// 'fn' returns true the loop ends and nil is returned.
+//
+// ErrWaitTimeout will be returned if the 'done' channel is closed without fn ever
+// returning true.
+//
+// When the done channel is closed, because the golang `select` statement is
+// "uniform pseudo-random", the `fn` might still run one or multiple time,
+// though eventually `WaitFor` will return.
+func WaitFor(wait WaitFunc, fn ConditionFunc, done <-chan struct{}) error {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c := wait(stopCh)
+	for {
+		select {
+		case _, open := <-c:
+			ok, err := fn()
+			if err != nil {
+				return err
+			}
+			if ok {
+				return nil
+			}
+			if !open {
+				return ErrWaitTimeout
+			}
+		case <-done:
+			return ErrWaitTimeout
+		}
+	}
+}
+
+// poller returns a WaitFunc that will send to the channel every interval until
+// timeout has elapsed and then closes the channel.
+//
+// Over very short intervals you may receive no ticks before the channel is
+// closed. A timeout of 0 is interpreted as an infinity.
+//
+// Output ticks are not buffered. If the channel is not ready to receive an
+// item, the tick is skipped.
+func poller(interval, timeout time.Duration) WaitFunc {
+	return WaitFunc(func(done <-chan struct{}) <-chan struct{} {
+		ch := make(chan struct{})
+
+		go func() {
+			defer close(ch)
+
+			tick := time.NewTicker(interval)
+			defer tick.Stop()
+
+			var after <-chan time.Time
+			if timeout != 0 {
+				// time.After is more convenient, but it
+				// potentially leaves timers around much longer
+				// than necessary if we exit early.
+				timer := time.NewTimer(timeout)
+				after = timer.C
+				defer timer.Stop()
+			}
+
+			for {
+				select {
+				case <-tick.C:
+					// If the consumer isn't ready for this signal drop it and
+					// check the other channels.
+					select {
+					case ch <- struct{}{}:
+					default:
+					}
+				case <-after:
+					return
+				case <-done:
+					return
+				}
+			}
+		}()
+
+		return ch
+	})
+}
+
+// resetOrReuseTimer avoids allocating a new timer if one is already in use.
+// Not safe for multiple threads.
+func resetOrReuseTimer(t *time.Timer, d time.Duration, sawTimeout bool) *time.Timer {
+	if t == nil {
+		return time.NewTimer(d)
+	}
+	if !t.Stop() && !sawTimeout {
+		<-t.C
+	}
+	t.Reset(d)
+	return t
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Introduce `TargetKind` type to limit usage of inline strings for target kind.
- Use client-go in shell command wherever possible.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
