### PR TITLE
Improve nodeSelector in shell cmd

### DIFF
--- a/cmd/drop_test.go
+++ b/cmd/drop_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Drop command", func() {
 			return command.Execute()
 		}
 	)
-	
+
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		targetReader = mockcmd.NewMockTargetReader(ctrl)

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -19,7 +19,7 @@ import (
 	mockcmd "github.com/gardener/gardenctl/pkg/mock/cmd"
 	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -54,7 +54,7 @@ var _ = Describe("Shell command", func() {
 
 	Context("without args", func() {
 		It("should list the node names", func() {
-			clientSet = fake.NewSimpleClientset(&v1.Node{
+			clientSet = fake.NewSimpleClientset(&corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "minikube",
 				},
@@ -98,7 +98,7 @@ var _ = Describe("Shell command", func() {
 			err := execute(command, []string{"minikube"})
 
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("node \"minikube\" not found"))
+			Expect(err.Error()).To(Equal("nodes \"minikube\" not found"))
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The value of kubernetes.io/hostname may be the same as the Node name in some environments and a different value in other environments ([source](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels)).
The PR removes the `strings.Contains(host["kubernetes.io/hostname"], name)` check which was preventing shell cmd to work with JeOS nodes.

**Which issue(s) this PR fixes**:
Ref #83 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
