### PR TITLE
List suggestions when gardenctl target garden is used

### DIFF
--- a/cmd/drop_test.go
+++ b/cmd/drop_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Drop command", func() {
 			return command.Execute()
 		}
 	)
-	
+
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		targetReader = mockcmd.NewMockTargetReader(ctrl)

--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_test
+
+import (
+	"github.com/gardener/gardenctl/cmd"
+	mockcmd "github.com/gardener/gardenctl/pkg/mock/cmd"
+	"github.com/golang/mock/gomock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Ls command", func() {
+
+	Describe("#PrintGardenClusters", func() {
+
+		var (
+			ctrl         *gomock.Controller
+			configReader *mockcmd.MockConfigReader
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			configReader = mockcmd.NewMockConfigReader(ctrl)
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should print Garden clusters", func() {
+			gardenConfig := &cmd.GardenConfig{
+				GardenClusters: []cmd.GardenClusterMeta{
+					{
+						Name: "prod-1",
+					},
+					{
+						Name: "prod-2",
+					},
+				},
+			}
+			configReader.EXPECT().ReadConfig(gomock.Any()).Return(gardenConfig)
+
+			ioStreams, _, out, _ := cmd.NewTestIOStreams()
+			cmd.PrintGardenClusters(configReader, "yaml", ioStreams)
+
+			Expect(out.String()).To(Equal("gardenClusters:\n- name: prod-1\n- name: prod-2\n"))
+		})
+	})
+})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,8 +131,8 @@ func init() {
 	cobra.EnableCommandSorting = false
 	cobra.EnablePrefixMatching = prefixMatching
 	RootCmd.AddCommand(
-		NewLsCmd(configReader),
-		NewTargetCmd(targetReader, targetWriter, configReader),
+		NewLsCmd(configReader, ioStreams),
+		NewTargetCmd(targetReader, targetWriter, configReader, ioStreams),
 		NewDropCmd(targetReader, targetWriter, ioStreams),
 		getCmd)
 	RootCmd.AddCommand(downloadCmd, showCmd, logsCmd)

--- a/cmd/target.go
+++ b/cmd/target.go
@@ -30,7 +30,7 @@ import (
 )
 
 // NewTargetCmd returns a new target command.
-func NewTargetCmd(targetReader TargetReader, targetWriter TargetWriter, configReader ConfigReader) *cobra.Command {
+func NewTargetCmd(targetReader TargetReader, targetWriter TargetWriter, configReader ConfigReader, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "target <project|garden|seed|shoot> NAME",
 		Short:        "Set scope for next operations",
@@ -41,9 +41,14 @@ func NewTargetCmd(targetReader TargetReader, targetWriter TargetWriter, configRe
 			}
 			switch args[0] {
 			case "garden":
-				if len(args) != 2 {
+				if len(args) == 1 {
+					// Print Garden clusters
+					PrintGardenClusters(configReader, "yaml", ioStreams)
+					return nil
+				} else if len(args) > 2 {
 					return errors.New("command must be in the format: target garden NAME")
 				}
+
 				gardens := resolveNameGarden(configReader, args[1])
 				if len(gardens) == 0 {
 					return fmt.Errorf("no match for %q", args[1])


### PR DESCRIPTION
**What this PR does / why we need it**:
List suggestions when `gardenctl target garden` is used.

**Which issue(s) this PR fixes**:
Fixes #86

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
