### PR TITLE
Use -mod=vendor

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -28,5 +28,6 @@ VERSION=$(cat ${SOURCE_PATH}/VERSION)
 ###############################################################################
 
 go build \
-  -ldflags "-w -X github.com/gardener/gardenctl/cmd.version=${VERSION} -w -X github.com/gardener/gardenctl/cmd.buildDate=${DATE}"\
+  -mod=vendor \
+  -ldflags "-w -X github.com/gardener/gardenctl/cmd.version=${VERSION} -w -X github.com/gardener/gardenctl/cmd.buildDate=${DATE}" \
   -o ${BINARY_PATH}/rel/gardenctl gardenctl.go

--- a/.ci/test
+++ b/.ci/test
@@ -16,7 +16,7 @@ fi
 cd "${SOURCE_PATH}"
 
 # Install Ginkgo (test framework) to be able to execute the tests.
-go get -u github.com/onsi/ginkgo/ginkgo
+GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
 
 ###############################################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /go/src/github.com/gardener/gardenctl &&\
     cd /go/src/github.com/gardener &&\
     git clone https://github.com/gardener/gardenctl.git &&\
     cd ./gardenctl &&\
-    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gardenctl .
+    CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -installsuffix cgo -o gardenctl .
 
 # minimal Ubuntu LTS version
 FROM ubuntu:18.04

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,12 @@ VERSION=$(shell cat VERSION | sed 's/[-dev]//g')
 .PHONY: build
 build:
 	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+		-mod=vendor \
 		-ldflags "-w -X github.com/gardener/gardenctl/cmd.version=${VERSION} -X github.com/gardener/gardenctl/cmd.buildDate=${DATE}" \
 		-o bin/linux-amd64/gardenctl-linux-amd64 gardenctl.go
 
 	@CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build \
+		-mod=vendor \
 		-ldflags "-w -X github.com/gardener/gardenctl/cmd.version=${VERSION} -X github.com/gardener/gardenctl/cmd.buildDate=${DATE}" \
 		-o bin/darwin-amd64/gardenctl-darwin-amd64 gardenctl.go
 


### PR DESCRIPTION
**What this PR does / why we need it**:
For cmd/go the default behaviour in go modules is to look up the proper modules through the network. `-mod=vendor` prevents that and forces the use of `vendor/`.
Ref golang/go#27227

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
