### PR TITLE
Improve completion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,6 @@ RUN pip install python-novaclient python-glanceclient python-cinderclient python
 RUN mkdir -p /opt/gardenctl/bin &&\
     mv gardenctl /opt/gardenctl/bin/gardenctl &&\
     ln -s /opt/gardenctl/bin/gardenctl /usr/local/bin/gardenctl &&\
-    gardenctl completion; mv gardenctl_completion.sh /root/gardenctl_completion.sh &&\
+    gardenctl completion bash > /root/gardenctl_bash_completion.sh &&\
     echo ". /etc/profile" >> /root/.bashrc &&\
-    echo ". /root/gardenctl_completion.sh" >> /root/.bashrc
+    echo ". /root/gardenctl_bash_completion.sh" >> /root/.bashrc

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sudo mv bin/darwin-amd64/gardenctl-darwin-amd64 /usr/local/bin/gardenctl
 `gardenctl` supports auto completion. This recommended feature is bound to `gardenctl` or the alias `g`. To configure it you can run:
 
 ```bash
-echo "gardenctl completion && source gardenctl_completion.sh && rm gardenctl_completion.sh" >> ~/.bashrc
+echo "source <(gardenctl completion bash)" >> ~/.bashrc
 source ~/.bashrc
 ```
 
@@ -100,11 +100,11 @@ Please check the IaaS provider documentation for more details about their CLIs.
 
 Moreover, `gardenctl` offers auto completion. To use it, the command
 ```bash
-gardenctl completion
+gardenctl completion bash
 ``` 
-creates the file `gardenctl_completion.sh` which can then be sourced later on via 
+print on the standard output a completion script which can be sourced via
 ```bash
-source gardenctl_completion.sh
+source <(gardenctl completion bash)
 ```
 Please keep in mind that the auto completion is bound to `gardenctl` or the alias `g`.
 

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -15,24 +15,39 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
-	Use:   "completion",
-	Short: "Generate bash-completion file\n",
+	Use:   "completion <bash|zsh>",
+	Short: "Generate bash or zsh completion script\n",
+	Long:  ``,
+}
+
+var bashCompletionCmd = &cobra.Command{
+	Use:   "bash",
+	Short: "Generate bash completion script",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		generateBashCompletion()
+		err := RootCmd.GenBashCompletion(os.Stdout)
+		checkError(err)
+	},
+}
+
+var zshCompletionCmd = &cobra.Command{
+	Use:   "zsh",
+	Short: "Generate zsh completion script",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := RootCmd.GenZshCompletion(os.Stdout)
+		checkError(err)
 	},
 }
 
 func init() {
-}
-
-//generate bash-completion file for gardenctl
-func generateBashCompletion() {
-	err := RootCmd.GenBashCompletionFile("gardenctl_completion.sh")
-	checkError(err)
+	completionCmd.AddCommand(bashCompletionCmd)
+	completionCmd.AddCommand(zshCompletionCmd)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Output the completion script to the std out.
Add experimental support for zsh.

**Which issue(s) this PR fixes**:
Fixes #102

**Special notes for your reviewer**:
/cc @vasu1124 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action user
`gardenctl completion` now accepts shell subcommand, `bash` or `zsh`.
```
```action user
`gardenctl completion <shell>` no longer print the completion script to the file `gardenctl_completion.sh` file, but on the standard output.
```
```improvement user
`gardenctl completion` has an experimental support for `zsh` shell.
```
