### PR TITLE
Improve target command

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -252,12 +252,13 @@ func getShoot(name string) {
 	checkError(err)
 	kubeSecret, err := Client.CoreV1().Secrets(seed.Spec.SecretRef.Namespace).Get(seed.Spec.SecretRef.Name, metav1.GetOptions{})
 	checkError(err)
-	pathSeed := pathSeedCache + "/" + seed.Spec.SecretRef.Name
+	gardenName := target.Stack()[0].Name
+	pathSeed := filepath.Join(pathGardenHome, "cache", gardenName, "seeds", seed.Spec.SecretRef.Name)
 	os.MkdirAll(pathSeed, os.ModePerm)
 	err = ioutil.WriteFile(pathSeed+"/kubeconfig.yaml", kubeSecret.Data["kubeconfig"], 0644)
 	checkError(err)
-	KUBECONFIG = pathSeed + "/kubeconfig.yaml"
-	pathToKubeconfig := pathGardenHome + "/cache/seeds" + "/" + seed.Spec.SecretRef.Name + "/" + "kubeconfig.yaml"
+	KUBECONFIG = filepath.Join(pathSeed, "kubeconfig.yaml")
+	pathToKubeconfig := filepath.Join(pathSeed, "kubeconfig.yaml")
 	config, err := clientcmd.BuildConfigFromFlags("", pathToKubeconfig)
 	checkError(err)
 	Client, err := k8s.NewForConfig(config)

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -449,7 +450,8 @@ func logsKubernetesDashboard() {
 		Client, err = clientToTarget("shoot")
 		checkError(err)
 	} else if len(target.Target) == 2 && target.Target[1].Kind == "seed" {
-		KUBECONFIG = pathGardenHome + "/cache/seeds" + "/" + target.Target[1].Name + "/" + "kubeconfig.yaml"
+		gardenName := target.Stack()[0].Name
+		KUBECONFIG = filepath.Join(pathGardenHome, "cache", gardenName, "seeds", target.Target[1].Name, "kubeconfig.yaml")
 		config, err := clientcmd.BuildConfigFromFlags("", KUBECONFIG)
 		checkError(err)
 		Client, err = kubernetes.NewForConfig(config)

--- a/pkg/cmd/operate.go
+++ b/pkg/cmd/operate.go
@@ -68,6 +68,11 @@ func operate(provider, arguments string) {
 	}
 	secret, err := Client.CoreV1().Secrets(namespaceSecret).Get((secretName), metav1.GetOptions{})
 	checkError(err)
+
+	gardenName := target.Stack()[0].Name
+	projectsPath := filepath.Join("cache", gardenName, "projects", target.Target[1].Name, target.Target[2].Name)
+	seedsPath := filepath.Join("cache", gardenName, "seeds", target.Target[1].Name, target.Target[2].Name)
+
 	switch provider {
 	case "aws":
 		accessKeyID := []byte(secret.Data["accessKeyID"])
@@ -76,13 +81,13 @@ func operate(provider, arguments string) {
 			awsPathCredentials := ""
 			awsPathConfig := ""
 			if target.Target[1].Kind == "project" {
-				CreateDir(pathGardenHome+"/cache/projects/"+target.Target[1].Name+"/"+target.Target[2].Name+"/.aws", 0751)
-				awsPathCredentials = "cache/projects/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aws/credentials"
-				awsPathConfig = "cache/projects/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aws/config"
+				CreateDir(filepath.Join(pathGardenHome, projectsPath, ".aws"), 0751)
+				awsPathCredentials = filepath.Join(projectsPath, ".aws", "credentials")
+				awsPathConfig = filepath.Join(projectsPath, ".aws", "config")
 			} else if target.Target[1].Kind == "seed" {
-				CreateDir(pathGardenHome+"/cache/seeds/"+target.Target[1].Name+"/"+target.Target[2].Name+"/.aws", 0751)
-				awsPathCredentials = "cache/seeds/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aws/credentials"
-				awsPathConfig = "cache/seeds/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aws/config"
+				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".aws"), 0751)
+				awsPathCredentials = filepath.Join(seedsPath, ".aws", "credentials")
+				awsPathConfig = filepath.Join(seedsPath, ".aws", "config")
 			}
 			CreateFileIfNotExists(pathGardenHome+"/"+awsPathCredentials, 0644)
 			CreateFileIfNotExists(pathGardenHome+"/"+awsPathConfig, 0644)
@@ -111,11 +116,11 @@ func operate(provider, arguments string) {
 		if !cachevar {
 			gcpPathCredentials := ""
 			if target.Target[1].Kind == "project" {
-				CreateDir(pathGardenHome+"/cache/projects/"+target.Target[1].Name+"/"+target.Target[2].Name+"/.gcp", 0751)
-				gcpPathCredentials = "cache/projects/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.gcp/credentials"
+				CreateDir(filepath.Join(pathGardenHome, projectsPath, ".gcp"), 0751)
+				gcpPathCredentials = filepath.Join(projectsPath, ".gcp", "credentials")
 			} else if target.Target[1].Kind == "seed" {
-				CreateDir(pathGardenHome+"/cache/seeds/"+target.Target[1].Name+"/"+target.Target[2].Name+"/.gcp", 0751)
-				gcpPathCredentials = "cache/seeds/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.gcp/credentials"
+				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".gcp"), 0751)
+				gcpPathCredentials = filepath.Join(seedsPath, ".gcp", "credentials")
 			}
 			CreateFileIfNotExists(pathGardenHome+"/"+gcpPathCredentials, 0644)
 			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, gcpPathCredentials), os.O_WRONLY, 0644)
@@ -167,11 +172,11 @@ func operate(provider, arguments string) {
 		if !cachevar {
 			azurePathCredentials := ""
 			if target.Target[1].Kind == "project" {
-				CreateDir(pathGardenHome+"/cache/projects/"+target.Target[1].Name+"/"+target.Target[2].Name+"/.azure", 0751)
-				azurePathCredentials = "cache/projects/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.azure/credentials"
+				CreateDir(filepath.Join(pathGardenHome, projectsPath, ".azure"), 0751)
+				azurePathCredentials = filepath.Join(projectsPath, ".azure", "credentials")
 			} else if target.Target[1].Kind == "seed" {
-				CreateDir(pathGardenHome+"/cache/seeds/"+target.Target[1].Name+"/"+target.Target[2].Name+"/.azure", 0751)
-				azurePathCredentials = "cache/seeds/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.azure/credentials"
+				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".azure"), 0751)
+				azurePathCredentials = filepath.Join(seedsPath, ".azure", "credentials")
 			}
 			CreateFileIfNotExists(pathGardenHome+"/"+azurePathCredentials, 0644)
 			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, azurePathCredentials), os.O_WRONLY, 0644)
@@ -204,11 +209,11 @@ func operate(provider, arguments string) {
 		if !cachevar {
 			openstackPathCredentials := ""
 			if target.Target[1].Kind == "project" {
-				CreateDir(pathGardenHome+"/cache/projects/"+target.Target[1].Name+"/"+target.Target[2].Name+"/.openstack", 0751)
-				openstackPathCredentials = "cache/projects/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.openstack/credentials"
+				CreateDir(filepath.Join(pathGardenHome, projectsPath, ".openstack"), 0751)
+				openstackPathCredentials = filepath.Join(projectsPath, ".openstack", "credentials")
 			} else if target.Target[1].Kind == "seed" {
-				CreateDir(pathGardenHome+"/cache/seeds/"+target.Target[1].Name+"/"+target.Target[2].Name+"/.openstack", 0751)
-				openstackPathCredentials = "cache/seeds/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.openstack/credentials"
+				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".openstack"), 0751)
+				openstackPathCredentials = filepath.Join(seedsPath, ".openstack", "credentials")
 			}
 			CreateFileIfNotExists(pathGardenHome+"/"+openstackPathCredentials, 0644)
 			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, openstackPathCredentials), os.O_WRONLY, 0644)
@@ -230,13 +235,13 @@ func operate(provider, arguments string) {
 			aliyunPathCredentials := ""
 			aliyunPathConfig := ""
 			if target.Target[1].Kind == "project" {
-				CreateDir(pathGardenHome+"/cache/projects/"+target.Target[1].Name+"/"+target.Target[2].Name+"/.aliyun", 0751)
-				aliyunPathCredentials = "cache/projects/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aliyun/credentials"
-				aliyunPathConfig = "cache/projects/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aliyun/config"
+				CreateDir(filepath.Join(pathGardenHome, projectsPath, ".aliyun"), 0751)
+				aliyunPathCredentials = filepath.Join(projectsPath, ".aliyun", "credentials")
+				aliyunPathConfig = filepath.Join(projectsPath, ".aliyun", "config")
 			} else if target.Target[1].Kind == "seed" {
-				CreateDir(pathGardenHome+"/cache/seeds/"+target.Target[1].Name+"/"+target.Target[2].Name+"/.aliyun", 0751)
-				aliyunPathCredentials = "cache/seeds/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aliyun/credentials"
-				aliyunPathConfig = "cache/seeds/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aliyun/config"
+				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".aliyun"), 0751)
+				aliyunPathCredentials = filepath.Join(seedsPath, ".aliyun", "credentials")
+				aliyunPathConfig = filepath.Join(seedsPath, ".aliyun", "config")
 			}
 			CreateFileIfNotExists(pathGardenHome+"/"+aliyunPathCredentials, 0644)
 			CreateFileIfNotExists(pathGardenHome+"/"+aliyunPathConfig, 0644)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -89,9 +89,6 @@ func Execute() {
 	} else if strings.Contains(pathGardenHome, "~") {
 		pathGardenHome = strings.Replace(pathGardenHome, "~", HomeDir(), 1)
 	}
-	pathSeedCache = filepath.Join(pathGardenHome, "cache", "seeds")
-	pathProjectCache = filepath.Join(pathGardenHome, "cache", "projects")
-	pathShootCache = filepath.Join(pathGardenHome, "cache", "shoots")
 	pathGardenConfig = filepath.Join(pathGardenHome, "config")
 	pathTarget = filepath.Join(pathGardenHome, "target")
 	CreateDir(pathGardenHome, 0751)
@@ -103,9 +100,6 @@ func Execute() {
 	if _, err := os.Stat(pathGardenConfig); err != nil {
 		CreateFileIfNotExists(pathGardenConfig, 0644)
 	}
-	CreateDir(pathGardenHome+"/cache", 0751)
-	CreateDir(pathGardenHome+"/cache/seeds", 0751)
-	CreateDir(pathGardenHome+"/cache/projects", 0751)
 	GetGardenClusterKubeConfigFromConfig(pathGardenConfig, pathTarget)
 	if err := RootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -292,6 +293,7 @@ func showMachineControllerManager() {
 func showKubernetesDashboard() {
 	var target Target
 	ReadTarget(pathTarget, &target)
+	gardenName := target.Stack()[0].Name
 	if len(target.Target) == 1 {
 		Client, err = clientToTarget("garden")
 		checkError(err)
@@ -305,7 +307,7 @@ func showKubernetesDashboard() {
 	} else if len(target.Target) == 2 {
 		namespace := "kube-system"
 		if len(target.Target) == 2 && target.Target[1].Kind == "seed" {
-			KUBECONFIG = pathGardenHome + "/cache/seeds" + "/" + target.Target[1].Name + "/" + "kubeconfig.yaml"
+			KUBECONFIG = filepath.Join(pathGardenHome, "cache", gardenName, "seeds", target.Target[1].Name, "kubeconfig.yaml")
 		} else if len(target.Target) == 2 && target.Target[1].Kind == "project" {
 			fmt.Println("Project targeted")
 			os.Exit(2)

--- a/pkg/cmd/ssh_for_alicloud.go
+++ b/pkg/cmd/ssh_for_alicloud.go
@@ -80,11 +80,12 @@ func sshToAlicloudNode(nodeIP, path string) {
 	configureAliyunCLI()
 	var target Target
 	ReadTarget(pathTarget, &target)
+	gardenName := target.Stack()[0].Name
 	aliyunPathSSHKey := ""
 	if target.Target[1].Kind == "project" {
-		aliyunPathSSHKey = pathGardenHome + "/cache/projects/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aliyun/"
+		aliyunPathSSHKey = pathGardenHome + "/cache/" + gardenName + "/projects/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aliyun/"
 	} else if target.Target[1].Kind == "seed" {
-		aliyunPathSSHKey = pathGardenHome + "/cache/seeds/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aliyun/"
+		aliyunPathSSHKey = pathGardenHome + "/cache/" + gardenName + "/seeds/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aliyun/"
 	}
 	err = ExecCmd(nil, "mv key "+aliyunPathSSHKey, false)
 	checkError(err)

--- a/pkg/cmd/var.go
+++ b/pkg/cmd/var.go
@@ -44,9 +44,6 @@ var (
 	password string
 
 	// file pathes
-	pathSeedCache    string
-	pathProjectCache string
-	pathShootCache   string
 	pathGardenConfig string
 	pathTarget       string
 	pathDefault      = filepath.Join(HomeDir(), ".garden")


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the `gardenctl target seed/shoot` commands navigates to `/cache/seeds/`. This may cause a problem which I will describe bellow:

### Reproducing

1) Let's open a terminal and target some garden cluster and after that some seed cluster , for example `aws`.
  This will create a file in .garden/cache/seeds/aws/kubeconfig.yaml and will print it.
2) export KUBECONFIG=.garden/cache/seeds/aws/kubeconfig.yaml
3) Open another terminal where we will target again seed called `aws` but from another garden cluster. This will override the file, which points the Kubeconfig from the first terminal.

### Solution
We can just add the garden cluster's name to the Kubeconfig's path


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vpnachev @DockToFuture @ialidzhikov 

**Release note**:
-->
```improvement operator
None
```
