### PR TITLE
Replace hard coded strings with filepath.Join

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -255,7 +255,7 @@ func getShoot(name string) {
 	gardenName := target.Stack()[0].Name
 	pathSeed := filepath.Join(pathGardenHome, "cache", gardenName, "seeds", seed.Spec.SecretRef.Name)
 	os.MkdirAll(pathSeed, os.ModePerm)
-	err = ioutil.WriteFile(pathSeed+"/kubeconfig.yaml", kubeSecret.Data["kubeconfig"], 0644)
+	err = ioutil.WriteFile(filepath.Join(pathSeed, "kubeconfig.yaml"), kubeSecret.Data["kubeconfig"], 0644)
 	checkError(err)
 	KUBECONFIG = filepath.Join(pathSeed, "kubeconfig.yaml")
 	pathToKubeconfig := filepath.Join(pathSeed, "kubeconfig.yaml")

--- a/pkg/cmd/operate.go
+++ b/pkg/cmd/operate.go
@@ -89,18 +89,18 @@ func operate(provider, arguments string) {
 				awsPathCredentials = filepath.Join(seedsPath, ".aws", "credentials")
 				awsPathConfig = filepath.Join(seedsPath, ".aws", "config")
 			}
-			CreateFileIfNotExists(pathGardenHome+"/"+awsPathCredentials, 0644)
-			CreateFileIfNotExists(pathGardenHome+"/"+awsPathConfig, 0644)
-			removeOldEntry(pathGardenHome+"/"+awsPathCredentials, "[gardenctl]")
-			removeOldEntry(pathGardenHome+"/"+awsPathConfig, "[profile gardenctl]")
+			CreateFileIfNotExists(filepath.Join(pathGardenHome, awsPathCredentials), 0644)
+			CreateFileIfNotExists(filepath.Join(pathGardenHome, awsPathConfig), 0644)
+			removeOldEntry(filepath.Join(pathGardenHome, awsPathCredentials), "[gardenctl]")
+			removeOldEntry(filepath.Join(pathGardenHome, awsPathConfig), "[profile gardenctl]")
 			credentials := "[gardenctl]\n" + "aws_access_key_id=" + string(accessKeyID[:]) + "\n" + "aws_secret_access_key=" + string(secretAccessKey[:]) + "\n"
-			originalCredentials, err := os.OpenFile(pathGardenHome+"/"+awsPathCredentials, os.O_APPEND|os.O_WRONLY, 0644)
+			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, awsPathCredentials), os.O_APPEND|os.O_WRONLY, 0644)
 			checkError(err)
 			_, err = originalCredentials.WriteString(credentials)
 			checkError(err)
 			originalCredentials.Close()
 			config := "[profile gardenctl]\n" + "region=" + region + "\n" + "output=text\n"
-			originalConfig, err := os.OpenFile(pathGardenHome+"/"+awsPathConfig, os.O_APPEND|os.O_WRONLY, 0644)
+			originalConfig, err := os.OpenFile(filepath.Join(pathGardenHome, awsPathConfig), os.O_APPEND|os.O_WRONLY, 0644)
 			_, err = originalConfig.WriteString(config)
 			originalConfig.Close()
 			checkError(err)
@@ -122,7 +122,7 @@ func operate(provider, arguments string) {
 				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".gcp"), 0751)
 				gcpPathCredentials = filepath.Join(seedsPath, ".gcp", "credentials")
 			}
-			CreateFileIfNotExists(pathGardenHome+"/"+gcpPathCredentials, 0644)
+			CreateFileIfNotExists(filepath.Join(pathGardenHome, gcpPathCredentials), 0644)
 			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, gcpPathCredentials), os.O_WRONLY, 0644)
 			checkError(err)
 			_, err = originalCredentials.WriteString(string(serviceaccount))
@@ -140,7 +140,7 @@ func operate(provider, arguments string) {
 			if err != nil {
 				os.Exit(2)
 			}
-			err = ExecCmd(nil, "gcloud auth activate-service-account --key-file="+pathGardenHome+"/"+gcpPathCredentials, false)
+			err = ExecCmd(nil, "gcloud auth activate-service-account --key-file="+filepath.Join(pathGardenHome, gcpPathCredentials), false)
 			if err != nil {
 				os.Exit(2)
 			}
@@ -178,7 +178,7 @@ func operate(provider, arguments string) {
 				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".azure"), 0751)
 				azurePathCredentials = filepath.Join(seedsPath, ".azure", "credentials")
 			}
-			CreateFileIfNotExists(pathGardenHome+"/"+azurePathCredentials, 0644)
+			CreateFileIfNotExists(filepath.Join(pathGardenHome, azurePathCredentials), 0644)
 			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, azurePathCredentials), os.O_WRONLY, 0644)
 			checkError(err)
 			credentials := "clientID: " + string(clientID[:]) + "\n" + "clientSecret: " + string(clientSecret[:]) + "\n" + "tenantID: " + string(tenantID[:]) + "\n"
@@ -215,7 +215,7 @@ func operate(provider, arguments string) {
 				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".openstack"), 0751)
 				openstackPathCredentials = filepath.Join(seedsPath, ".openstack", "credentials")
 			}
-			CreateFileIfNotExists(pathGardenHome+"/"+openstackPathCredentials, 0644)
+			CreateFileIfNotExists(filepath.Join(pathGardenHome, openstackPathCredentials), 0644)
 			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, openstackPathCredentials), os.O_WRONLY, 0644)
 			checkError(err)
 			credentials := "authURL: " + authURL + "\n" + "domainName: " + string(domainName[:]) + "\n" + "password: " + string(password[:]) + "\n" + "tenantName: " + string(tenantName[:]) + "\n" + "username: " + string(username[:]) + "\n"
@@ -243,18 +243,18 @@ func operate(provider, arguments string) {
 				aliyunPathCredentials = filepath.Join(seedsPath, ".aliyun", "credentials")
 				aliyunPathConfig = filepath.Join(seedsPath, ".aliyun", "config")
 			}
-			CreateFileIfNotExists(pathGardenHome+"/"+aliyunPathCredentials, 0644)
-			CreateFileIfNotExists(pathGardenHome+"/"+aliyunPathConfig, 0644)
-			removeOldEntry(pathGardenHome+"/"+aliyunPathCredentials, "[gardenctl]")
-			removeOldEntry(pathGardenHome+"/"+aliyunPathConfig, "[profile gardenctl]")
+			CreateFileIfNotExists(filepath.Join(pathGardenHome, aliyunPathCredentials), 0644)
+			CreateFileIfNotExists(filepath.Join(pathGardenHome, aliyunPathConfig), 0644)
+			removeOldEntry(filepath.Join(pathGardenHome, aliyunPathCredentials), "[gardenctl]")
+			removeOldEntry(filepath.Join(pathGardenHome, aliyunPathConfig), "[profile gardenctl]")
 			credentials := "[gardenctl]\n" + "accessKeyId=" + string(accessKeyID[:]) + "\n" + "accessKeySecret=" + string(accessKeySecret[:]) + "\n"
-			originalCredentials, err := os.OpenFile(pathGardenHome+"/"+aliyunPathCredentials, os.O_APPEND|os.O_WRONLY, 0644)
+			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, aliyunPathCredentials), os.O_APPEND|os.O_WRONLY, 0644)
 			checkError(err)
 			defer originalCredentials.Close()
 			_, err = originalCredentials.WriteString(credentials)
 			checkError(err)
 			config := "[profile gardenctl]\n" + "region=" + region + "\n" + "output=json\n"
-			originalConfig, err := os.OpenFile(pathGardenHome+"/"+aliyunPathConfig, os.O_APPEND|os.O_WRONLY, 0644)
+			originalConfig, err := os.OpenFile(filepath.Join(pathGardenHome, aliyunPathConfig), os.O_APPEND|os.O_WRONLY, 0644)
 			checkError(err)
 			defer originalConfig.Close()
 			_, err = originalConfig.WriteString(config)

--- a/pkg/cmd/register.go
+++ b/pkg/cmd/register.go
@@ -90,9 +90,9 @@ func NewRegisterCmd() *cobra.Command {
 				if err != nil && strings.Contains(err.Error(), AdminClusterRoleBindingName) {
 					kubeSecret, err := clientset.CoreV1().Secrets("garden").Get("virtual-garden-kubeconfig-for-admin", metav1.GetOptions{})
 					checkError(err)
-					virtualPath := pathDefault + "/virtual"
+					virtualPath := filepath.Join(pathDefault, "virtual")
 					os.MkdirAll(virtualPath, os.ModePerm)
-					virtualPathKubeConfig := virtualPath + "/virtualKubeConfig.yaml"
+					virtualPathKubeConfig := filepath.Join(virtualPath, "virtualKubeConfig.yaml")
 					err = ioutil.WriteFile(virtualPathKubeConfig, kubeSecret.Data["kubeconfig"], 0644)
 					checkError(err)
 					config, err := clientcmd.BuildConfigFromFlags("", virtualPathKubeConfig)
@@ -135,9 +135,9 @@ func NewRegisterCmd() *cobra.Command {
 					if err != nil && strings.Contains(err.Error(), AdminClusterRoleBindingName) {
 						kubeSecret, err := clientset.CoreV1().Secrets("garden").Get("virtual-garden-kubeconfig-for-admin", metav1.GetOptions{})
 						checkError(err)
-						virtualPath := pathDefault + "/virtual"
+						virtualPath := filepath.Join(pathDefault, "virtual")
 						os.MkdirAll(virtualPath, os.ModePerm)
-						virtualPathKubeConfig := virtualPath + "/virtualKubeConfig.yaml"
+						virtualPathKubeConfig := filepath.Join(virtualPath, "virtualKubeConfig.yaml")
 						err = ioutil.WriteFile(virtualPathKubeConfig, kubeSecret.Data["kubeconfig"], 0644)
 						checkError(err)
 						config, err = clientcmd.BuildConfigFromFlags("", virtualPathKubeConfig)

--- a/pkg/cmd/ssh.go
+++ b/pkg/cmd/ssh.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	v1alpha1 "github.com/gardener/gardener/pkg/client/core/clientset/versioned/typed/core/v1alpha1"
@@ -107,7 +108,7 @@ func NewSSHCmd(reader TargetReader, ioStreams IOStreams) *cobra.Command {
 			}
 			path := downloadTerraformFiles("infra")
 			if path != "" {
-				path += "/terraform.tfstate"
+				path = filepath.Join(path, "terraform.tfstate")
 			}
 			pathToKey := downloadSSHKeypair()
 			fmt.Printf(pathToKey)
@@ -260,7 +261,7 @@ func downloadSSHKeypair() string {
 	checkError(err)
 	pathSSKeypair, err := os.Getwd()
 	checkError(err)
-	err = ioutil.WriteFile(pathSSKeypair+"/key", []byte(secret.Data["id_rsa"]), 0600)
+	err = ioutil.WriteFile(filepath.Join(pathSSKeypair, "key"), []byte(secret.Data["id_rsa"]), 0600)
 	checkError(err)
 	return "Downloaded id_rsa key\n"
 }

--- a/pkg/cmd/ssh_for_alicloud.go
+++ b/pkg/cmd/ssh_for_alicloud.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -83,9 +84,9 @@ func sshToAlicloudNode(nodeIP, path string) {
 	gardenName := target.Stack()[0].Name
 	aliyunPathSSHKey := ""
 	if target.Target[1].Kind == "project" {
-		aliyunPathSSHKey = pathGardenHome + "/cache/" + gardenName + "/projects/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aliyun/"
+		aliyunPathSSHKey = filepath.Join(pathGardenHome, "cache", gardenName, "projects", target.Target[1].Name, target.Target[2].Name, ".aliyun") + string(filepath.Separator)
 	} else if target.Target[1].Kind == "seed" {
-		aliyunPathSSHKey = pathGardenHome + "/cache/" + gardenName + "/seeds/" + target.Target[1].Name + "/" + target.Target[2].Name + "/.aliyun/"
+		aliyunPathSSHKey = filepath.Join(pathGardenHome, "cache", gardenName, "seeds", target.Target[1].Name, target.Target[2].Name, ".aliyun") + string(filepath.Separator)
 	}
 	err = ExecCmd(nil, "mv key "+aliyunPathSSHKey, false)
 	checkError(err)

--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -383,11 +383,11 @@ func targetSeed(targetReader TargetReader, targetWriter TargetWriter, name strin
 	checkError(err)
 	pathSeed := filepath.Join(pathGardenHome, "cache", gardenName, "seeds", name)
 	os.MkdirAll(pathSeed, os.ModePerm)
-	err = ioutil.WriteFile(pathSeed+"/kubeconfig.yaml", kubeSecret.Data["kubeconfig"], 0644)
+	err = ioutil.WriteFile(filepath.Join(pathSeed, "kubeconfig.yaml"), kubeSecret.Data["kubeconfig"], 0644)
 	checkError(err)
-	KUBECONFIG = pathSeed + "/kubeconfig.yaml"
+	KUBECONFIG = filepath.Join(pathSeed, "kubeconfig.yaml")
 	if !cachevar && cache {
-		err = ioutil.WriteFile(pathSeed+"/kubeconfig.yaml", kubeSecret.Data["kubeconfig"], 0644)
+		err = ioutil.WriteFile(filepath.Join(pathSeed, "kubeconfig.yaml"), kubeSecret.Data["kubeconfig"], 0644)
 		checkError(err)
 	}
 

--- a/pkg/cmd/unregister.go
+++ b/pkg/cmd/unregister.go
@@ -81,9 +81,9 @@ func NewUnregisterCmd() *cobra.Command {
 				if err != nil && strings.Contains(err.Error(), AdminClusterRoleBindingName) {
 					kubeSecret, err := clientset.CoreV1().Secrets("garden").Get("virtual-garden-kubeconfig-for-admin", metav1.GetOptions{})
 					checkError(err)
-					virtualPath := pathDefault + "/virtual"
+					virtualPath := filepath.Join(pathDefault, "virtual")
 					os.MkdirAll(virtualPath, os.ModePerm)
-					virtualPathKubeConfig := virtualPath + "/virtualKubeConfig.yaml"
+					virtualPathKubeConfig := filepath.Join(virtualPath, "virtualKubeConfig.yaml")
 					err = ioutil.WriteFile(virtualPathKubeConfig, kubeSecret.Data["kubeconfig"], 0644)
 					checkError(err)
 					config, err := clientcmd.BuildConfigFromFlags("", virtualPathKubeConfig)
@@ -121,9 +121,9 @@ func NewUnregisterCmd() *cobra.Command {
 					if err != nil && strings.Contains(err.Error(), AdminClusterRoleBindingName) {
 						kubeSecret, err := clientset.CoreV1().Secrets("garden").Get("virtual-garden-kubeconfig-for-admin", metav1.GetOptions{})
 						checkError(err)
-						virtualPath := pathDefault + "/virtual"
+						virtualPath := filepath.Join(pathDefault, "virtual")
 						os.MkdirAll(virtualPath, os.ModePerm)
-						virtualPathKubeConfig := virtualPath + "/virtualKubeConfig.yaml"
+						virtualPathKubeConfig := filepath.Join(virtualPath, "virtualKubeConfig.yaml")
 						err = ioutil.WriteFile(virtualPathKubeConfig, kubeSecret.Data["kubeconfig"], 0644)
 						checkError(err)
 						config, err = clientcmd.BuildConfigFromFlags("", virtualPathKubeConfig)


### PR DESCRIPTION
**What this PR does / why we need it**:

Replace hard coded paths with filepath.Join(). 
In this way, the paths will be relevant to Windows systems too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@ialidzhikov @DockToFuture 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
