### PR TITLE
Automate ssh cmd for aws, azure and gcp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gardener/gardenctl
 go 1.13
 
 require (
+	github.com/Masterminds/semver v1.4.2
 	github.com/badoux/checkmail v0.0.0-20181210160741-9661bd69e9ad
 	github.com/gardener/gardener v0.0.0-20191018063251-c1b318de841e
 	github.com/gardener/gardener-extensions v0.0.0-20190906160200-5c329d46ae81

--- a/pkg/cmd/ssh_alicloud.go
+++ b/pkg/cmd/ssh_alicloud.go
@@ -65,9 +65,9 @@ type AliyunInstanceTypeSpec struct {
 }
 
 // sshToAlicloudNode provides cmds to ssh to alicloud via a public ip and clean it up afterwards.
-func sshToAlicloudNode(nodeIP, path string, sshPublicKey []byte) {
+func sshToAlicloudNode(nodeIP, path, user string, sshPublicKey []byte) {
 	// Check if this is a cleanup command
-	if nodeIP == "clean" {
+	if nodeIP == "cleanup" {
 		cleanupAlicloudBastionHost()
 		return
 	}
@@ -111,7 +111,7 @@ func sshToAlicloudNode(nodeIP, path string, sshPublicKey []byte) {
 
 	fmt.Println("")
 	fmt.Println("- Fill in the placeholders and run the following command to ssh onto the target node. For more information about the user, you can check the documentation of the cloud provider:")
-	fmt.Println("ssh -i " + aliyunPathSSHKey + "key -o \"ProxyCommand ssh -i " + aliyunPathSSHKey + "key -W " + nodeIP + ":22 gardener@" + a.BastionIP + "\" <user>@" + nodeIP)
+	fmt.Println("ssh -i " + aliyunPathSSHKey + "key -o \"ProxyCommand ssh -i " + aliyunPathSSHKey + "key -W " + nodeIP + ":22 " + user + "@" + a.BastionIP + "\" " + user + " @" + nodeIP)
 	fmt.Println("")
 	fmt.Println("- Run following command to hibernate bastion host:")
 	fmt.Println("gardenctl aliyun ecs StopInstance -- --InstanceId=" + a.BastionInstanceID)

--- a/pkg/cmd/ssh_aws.go
+++ b/pkg/cmd/ssh_aws.go
@@ -1,0 +1,320 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// AwsInstanceAttribute stores all the critical information for creating an instance on AWS.
+type AwsInstanceAttribute struct {
+	ShootName                string
+	InstanceID               string
+	SecurityGroupName        string
+	SecurityGroupID          string
+	ImageID                  string
+	VpcID                    string
+	KeyName                  string
+	SubnetID                 string
+	BastionSecurityGroupID   string
+	BastionInstanceName      string
+	BastionIP                string
+	BastionInstanceID        string
+	BastionSecurityGroupName string
+	UserData                 []byte
+	SSHPublicKey             []byte
+}
+
+// sshToAWSNode provides cmds to ssh to aws via a bastions host and clean it up afterwards
+func sshToAWSNode(nodeIP, path, user string, sshPublicKey []byte) {
+	a := &AwsInstanceAttribute{}
+	a.SSHPublicKey = sshPublicKey
+	fmt.Println("")
+
+	fmt.Println("(1/4) Fetching data from target shoot cluster")
+	a.fetchAwsAttributes(nodeIP, path)
+	fmt.Println("Data fetched from target shoot cluster.")
+	fmt.Println("")
+
+	fmt.Println("(2/4) Setting up bastion host security group")
+	a.createBastionHostSecurityGroup()
+	fmt.Println("")
+
+	fmt.Println("(3/4) Creating bastion host")
+	a.createBastionHostInstance()
+
+	bastionNode := user + "@" + a.BastionIP
+	node := user + "@" + nodeIP
+	fmt.Println("Waiting 45 seconds until ports are open.")
+	time.Sleep(45 * time.Second)
+
+	sshCmd := fmt.Sprintf("ssh -i key -o \"ProxyCommand ssh -W %%h:%%p -i key -o StrictHostKeyChecking=no " + bastionNode + "\" " + node + " -o StrictHostKeyChecking=no")
+	cmd := exec.Command("bash", "-c", sshCmd)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	checkError(err)
+
+	fmt.Println("(4/4) Cleanup")
+	a.cleanupAwsBastionHost()
+}
+
+// fetchAwsAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeIP>.
+func (a *AwsInstanceAttribute) fetchAwsAttributes(nodeIP, path string) {
+	a.ShootName = getShootClusterName()
+	a.InstanceID = getAwsInstanceIDForIP(nodeIP)
+	terraformVersion, err := ExecCmdReturnOutput("bash", "-c", "cat "+path+"  | jq -r .terraform_version")
+	checkError(err)
+	c, err := semver.NewConstraint(">= 0.12.0")
+	if err != nil {
+		fmt.Println("Handle version not being parsable.")
+		os.Exit(2)
+	}
+	v, err := semver.NewVersion(terraformVersion)
+	if err != nil {
+		fmt.Println("Handle version not being parsable.")
+		os.Exit(2)
+	}
+	if c.Check(v) {
+		subnetID, err := ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r .outputs.subnet_public_utility_z0.value")
+		checkError(err)
+		a.SubnetID = subnetID
+		vpcID, err := ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r .outputs.vpc_id.value")
+		checkError(err)
+		a.VpcID = vpcID
+	} else {
+		subnetID, err := ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r .modules[].outputs.subnet_public_utility_z0.value")
+		checkError(err)
+		a.SubnetID = subnetID
+		vpcID, err := ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r .modules[].outputs.vpc_id.value")
+		checkError(err)
+		a.VpcID = vpcID
+	}
+	a.SecurityGroupName = a.ShootName + "-nodes"
+	a.getSecurityGroupID()
+	a.BastionInstanceName = a.ShootName + "-bastions"
+	a.BastionSecurityGroupName = a.ShootName + "-bsg"
+	a.ImageID, err = fetchAWSImageIDByInstancePrivateIP(nodeIP)
+	checkError(err)
+	a.KeyName = a.ShootName + "-ssh-publickey"
+	a.UserData = getBastionUserData(a.SSHPublicKey)
+}
+
+// fetchAWSImageIDByInstancePrivateIP returns the image ID (AMI) for instance with the given <privateIP>.
+func fetchAWSImageIDByInstancePrivateIP(privateIP string) (string, error) {
+	command := fmt.Sprintf("aws ec2 describe-instances --filters Name=private-ip-address,Values=%s --query Reservations[0].Instances[0].ImageId", privateIP)
+	captured := capture()
+	operate("aws", command)
+	output, err := captured()
+	if err != nil || output == "None" {
+		return "", fmt.Errorf("could not fetch image ID (AMI) of instance with private IP address %q", privateIP)
+	}
+	return output, nil
+}
+
+// createBastionHostSecurityGroup finds the or creates a security group for the bastion host.
+func (a *AwsInstanceAttribute) createBastionHostSecurityGroup() {
+	var err error
+	// check if security group exists
+	a.getBastionSecurityGroupID()
+	if a.BastionSecurityGroupID != "" {
+		fmt.Println("Security Group exists, skipping creation.")
+		return
+	}
+
+	// create security group and ssh rule
+	arguments := fmt.Sprintf("aws ec2 create-security-group --group-name %s --description ssh-access --vpc-id %s", a.BastionSecurityGroupName, a.VpcID)
+	captured := capture()
+	operate("aws", arguments)
+	capturedOutput, err := captured()
+	checkError(err)
+	a.BastionSecurityGroupID = strings.Trim((capturedOutput), "\n")
+	arguments = fmt.Sprintf("aws ec2 authorize-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr 0.0.0.0/0", a.BastionSecurityGroupID)
+	operate("aws", arguments)
+	fmt.Println("Bastion host security group set up.")
+
+	// add shh rule to ec2 instance
+	arguments = fmt.Sprintf("aws ec2 authorize-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr 0.0.0.0/0", a.SecurityGroupID)
+	captured = capture()
+	operate("aws", arguments)
+	_, err = captured()
+	checkError(err)
+	fmt.Println("Opend SSH Port on Node.")
+}
+
+// getSecurityGroupID extracts security group id of ec2 instance
+func (a *AwsInstanceAttribute) getSecurityGroupID() {
+	var err error
+	arguments := fmt.Sprintf("aws ec2 describe-security-groups --filters Name=vpc-id,Values=%s Name=group-name,Values=%s --query SecurityGroups[*].{ID:GroupId}", a.VpcID, a.SecurityGroupName)
+	captured := capture()
+	operate("aws", arguments)
+	a.SecurityGroupID, err = captured()
+	checkError(err)
+}
+
+// getBastionSecurityGroupID extracts security group id for bastion security group
+func (a *AwsInstanceAttribute) getBastionSecurityGroupID() {
+	var err error
+	arguments := fmt.Sprintf("aws ec2 describe-security-groups --filters Name=vpc-id,Values=%s Name=group-name,Values=%s --query SecurityGroups[*].{ID:GroupId}", a.VpcID, a.BastionSecurityGroupName)
+	captured := capture()
+	operate("aws", arguments)
+	a.BastionSecurityGroupID, err = captured()
+	checkError(err)
+}
+
+// getAwsInstanceIDForIP returns the instance ID with the given <nodeIP>.
+func getAwsInstanceIDForIP(ip string) string {
+	typeName, err := getTargetType()
+	checkError(err)
+	Client, err = clientToTarget(typeName)
+	checkError(err)
+	nodes, err := Client.CoreV1().Nodes().List(metav1.ListOptions{})
+	checkError(err)
+	for _, node := range nodes.Items {
+		if ip == node.Status.Addresses[0].Address {
+			for _, v := range strings.Split(node.Spec.ProviderID, "/") {
+				if strings.HasPrefix(v, "i-") {
+					return v
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// getBastionHostInstance gets bastion host instance if it exists
+func (a *AwsInstanceAttribute) getBastionHostInstance() {
+	var err error
+	arguments := fmt.Sprintf("aws ec2 describe-instances --filter Name=vpc-id,Values=%s Name=tag:Name,Values=%s Name=instance-state-name,Values=running --query Reservations[*].Instances[].{Instance:InstanceId} --output text", a.VpcID, a.BastionSecurityGroupName)
+	captured := capture()
+	operate("aws", arguments)
+	a.BastionInstanceID, err = captured()
+	checkError(err)
+}
+
+// createBastionHostInstance find or creates a bastion host instance.
+func (a *AwsInstanceAttribute) createBastionHostInstance() {
+
+	// check if bastion host exists
+	a.getBastionHostInstance()
+	if a.BastionInstanceID != "" {
+		fmt.Println("Bastion Host exists, skipping creation.")
+		return
+	}
+
+	tmpfile, err := ioutil.TempFile(os.TempDir(), "gardener-user.sh")
+	checkError(err)
+	defer os.Remove(tmpfile.Name())
+	_, err = tmpfile.Write(a.UserData)
+	checkError(err)
+
+	// create bastion host
+	arguments := "aws " + fmt.Sprintf("ec2 run-instances --iam-instance-profile Name=%s --image-id %s --count 1 --instance-type t2.nano --key-name %s --security-group-ids %s --subnet-id %s --associate-public-ip-address --user-data file://%s --tag-specifications ResourceType=instance,Tags=[{Key=Name,Value=%s}]", a.BastionInstanceName, a.ImageID, a.KeyName, a.BastionSecurityGroupID, a.SubnetID, tmpfile.Name(), a.BastionInstanceName)
+	captured := capture()
+	operate("aws", arguments)
+	capturedOutput, err := captured()
+	checkError(err)
+	words := strings.Fields(capturedOutput)
+	for _, value := range words {
+		if strings.HasPrefix(value, "i-") {
+			a.BastionInstanceID = value
+		}
+	}
+	fmt.Println("Bastion host instance created.")
+	fmt.Println("")
+
+	// check if bastion host is up and running, timeout after 3 minutes
+	attemptCnt := 0
+	for attemptCnt < 60 {
+		arguments = "aws ec2 describe-instances --instance-id=" + a.BastionInstanceID + " --query Reservations[*].Instances[].[State.Name] --output text"
+		captured = capture()
+		operate("aws", arguments)
+		capturedOutput, err = captured()
+		checkError(err)
+		fmt.Println("Instance State: " + capturedOutput)
+		if strings.Trim(capturedOutput, "\n") == "running" {
+			arguments := "aws ec2 describe-instances --instance-id " + a.BastionInstanceID
+			captured := capture()
+			operate("aws", arguments)
+			capturedOutput, err := captured()
+			words := strings.Fields(capturedOutput)
+			checkError(err)
+			ip := ""
+			for _, value := range words {
+				if isIP(value) && !strings.HasPrefix(value, "10.") {
+					ip = value
+					break
+				}
+			}
+			a.BastionIP = ip
+			return
+		}
+		time.Sleep(time.Second * 2)
+		attemptCnt++
+	}
+	if attemptCnt == 90 {
+		fmt.Println("Bastion server instance timeout. Please try again.")
+		os.Exit(2)
+	}
+}
+
+// cleanupAwsBastionHost cleans up the bastion host for the targeted cluster.
+func (a *AwsInstanceAttribute) cleanupAwsBastionHost() {
+	fmt.Println("Cleaning up bastion host configurations...")
+	fmt.Println("")
+	fmt.Println("Starting cleanup")
+	fmt.Println("")
+
+	// clean up bastion host instance
+	fmt.Println("  (1/3) Cleaning up bastion host instance")
+	arguments := fmt.Sprintf("aws ec2 terminate-instances --instance-ids %s", a.BastionInstanceID)
+	captured := capture()
+	operate("aws", arguments)
+	capturedOutput, err := captured()
+	checkError(err)
+	fmt.Println(capturedOutput)
+
+	// remove shh rule from ec2 instance
+	fmt.Println("  (2/3) Close SSH Port on Node.")
+	arguments = fmt.Sprintf("aws ec2 revoke-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr 0.0.0.0/0", a.SecurityGroupID)
+	captured = capture()
+	operate("aws", arguments)
+	capturedOutput, err = captured()
+	checkError(err)
+	fmt.Println("  Closed SSH Port on Node.")
+	fmt.Println(capturedOutput)
+
+	// clean up bastion security group
+	fmt.Println("  (3/3) Clean up bastion host security group")
+	fmt.Println("")
+	fmt.Println("  Waiting 45 seconds until instance is deleted to remove all dependencies.")
+	time.Sleep(time.Second * 45)
+	arguments = fmt.Sprintf("aws ec2 delete-security-group --group-id %s", a.BastionSecurityGroupID)
+	captured = capture()
+	operate("aws", arguments)
+	_, err = captured()
+	checkError(err)
+	fmt.Println("")
+	fmt.Println("Bastion host configurations successfully cleaned up.")
+}

--- a/pkg/cmd/ssh_azure.go
+++ b/pkg/cmd/ssh_azure.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/jmoiron/jsonq"
+)
+
+// AzureInstanceAttribute stores all the critical information for creating an instance on Azure.
+type AzureInstanceAttribute struct {
+	NamePublicIP       string
+	ShootName          string
+	InstanceID         string
+	NicName            string
+	PublicIP           string
+	RescourceGroupName string
+	SecurityGroupName  string
+	SkuType            string
+}
+
+// sshToAZNode provides cmds to ssh to az via a public ip and clean it up afterwards
+func sshToAZNode(nodeIP, path, user string, sshPublicKey []byte) {
+	a := &AzureInstanceAttribute{}
+
+	fmt.Println("")
+	fmt.Println("(1/4) Fetching data from target shoot cluster")
+	a.fetchAzureAttributes(nodeIP, path)
+	fmt.Println("Data fetched from target shoot cluster.")
+	fmt.Println("")
+
+	fmt.Println("(2/4) Configuring Azure")
+
+	// add nsg rule
+	a.addNsgRule()
+	fmt.Println("")
+
+	// create public ip
+	a.createPublicIP()
+	fmt.Println("Waiting 5 s until public ip is available.")
+	fmt.Println("")
+	time.Sleep(5 * time.Second)
+
+	// update nic ip-config
+	a.configureNic()
+
+	node := user + "@" + a.PublicIP
+	fmt.Println("Waiting 30 seconds until ports are open.")
+	time.Sleep(30 * time.Second)
+	fmt.Println("(3/4) Establishing SSH connection")
+	fmt.Println("")
+
+	sshCmd := fmt.Sprintf("ssh -i key -o StrictHostKeyChecking=no " + node)
+	cmd := exec.Command("bash", "-c", sshCmd)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	checkError(err)
+
+	fmt.Println("")
+	fmt.Println("(4/4) Cleanup")
+	a.cleanupAzure()
+}
+
+// fetchAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeIP>.
+func (a *AzureInstanceAttribute) fetchAzureAttributes(nodeIP, path string) {
+	a.NamePublicIP = "sshIP"
+	var err error
+	terraformVersion, err := ExecCmdReturnOutput("bash", "-c", "cat "+path+"  | jq -r .terraform_version")
+	checkError(err)
+	c, err := semver.NewConstraint(">= 0.12.0")
+	if err != nil {
+		fmt.Println("Handle version not being parsable.")
+		os.Exit(2)
+	}
+	v, err := semver.NewVersion(terraformVersion)
+	if err != nil {
+		fmt.Println("Handle version not being parsable.")
+		os.Exit(2)
+	}
+	if c.Check(v) {
+		a.RescourceGroupName, err = ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r '.outputs.resourceGroupName.value'")
+		checkError(err)
+		a.SecurityGroupName, err = ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r '.outputs.securityGroupName.value'")
+		checkError(err)
+	} else {
+		a.RescourceGroupName, err = ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r '.modules[].outputs.resourceGroupName.value'")
+		checkError(err)
+		a.SecurityGroupName, err = ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r '.modules[].outputs.securityGroupName.value'")
+		checkError(err)
+	}
+
+	targetNode := getNodeForIP(nodeIP)
+	if targetNode == nil {
+		fmt.Println("No node found for ip")
+		os.Exit(2)
+	}
+
+	// remove invisible controll character which are somehow encoded in the *v1.Node object
+	re := regexp.MustCompile("[[:^ascii:]]")
+	a.NicName = re.ReplaceAllLiteralString(targetNode.Name+"-nic", "")
+
+	// parse sku type (Basic,Standard,...) from lbs
+	arguments := fmt.Sprintf("az network lb list --resource-group %s", a.RescourceGroupName)
+	captured := capture()
+	operate("az", arguments)
+	skuType, err := captured()
+	checkError(err)
+	tmpfile, err := ioutil.TempFile(os.TempDir(), "lbs.json")
+	checkError(err)
+	defer os.Remove(tmpfile.Name())
+	_, err = tmpfile.Write([]byte(skuType))
+	checkError(err)
+	skuType, err = ExecCmdReturnOutput("bash", "-c", "cat "+tmpfile.Name()+" | jq .[0].sku.name")
+	a.SkuType = strings.Trim(skuType, "\"")
+	fmt.Println(a.SkuType)
+	checkError(err)
+}
+
+// addNsgRule creates a nsg rule to open the ssh port
+func (a *AzureInstanceAttribute) addNsgRule() {
+	fmt.Println("Opened SSH Port.")
+	arguments := fmt.Sprintf("az network nsg rule create --resource-group %s  --nsg-name %s --name ssh --protocol Tcp --priority 1000 --destination-port-range 22", a.RescourceGroupName, a.SecurityGroupName)
+	operate("az", arguments)
+}
+
+// createPublicIP creates the public ip for nic
+func (a *AzureInstanceAttribute) createPublicIP() {
+	var err error
+	fmt.Println("Create public ip")
+	arguments := fmt.Sprintf("az network public-ip create -g %s -n %s --sku %s --allocation-method static", a.RescourceGroupName, a.NamePublicIP, a.SkuType)
+	captured := capture()
+	operate("az", arguments)
+	a.PublicIP, err = captured()
+	checkError(err)
+	fmt.Println(a.PublicIP)
+	data := map[string]interface{}{}
+	dec := json.NewDecoder(strings.NewReader(a.PublicIP))
+	err = dec.Decode(&data)
+	checkError(err)
+	jq := jsonq.NewQuery(data)
+	a.PublicIP, err = jq.String("publicIp", "ipAddress")
+	if err != nil {
+		os.Exit(2)
+	}
+}
+
+// configureNic attaches a public ip to the nic
+func (a *AzureInstanceAttribute) configureNic() {
+	var err error
+	fmt.Println("Add public ip to nic")
+	fmt.Println("")
+	arguments := fmt.Sprintf("az network nic ip-config update -g %s --nic-name %s --public-ip-address %s -n %s", a.RescourceGroupName, a.NicName, a.NamePublicIP, a.NicName)
+	captured := capture()
+	operate("az", arguments)
+	_, err = captured()
+	checkError(err)
+}
+
+// cleanupAzure cleans up all created azure resources required for ssh connection
+func (a *AzureInstanceAttribute) cleanupAzure() {
+	var err error
+
+	// remove ssh rule
+	fmt.Println("")
+	fmt.Println("  (1/3) Remove SSH rule")
+	arguments := fmt.Sprintf("az network nsg rule delete --resource-group %s  --nsg-name %s --name ssh", a.RescourceGroupName, a.SecurityGroupName)
+	captured := capture()
+	operate("az", arguments)
+	_, err = captured()
+	checkError(err)
+
+	// remove public ip address from nic
+	fmt.Println("")
+	fmt.Println("  (2/3) Remove public ip from nic")
+	arguments = fmt.Sprintf("az network nic ip-config update -g %s --nic-name %s --public-ip-address %s -n %s --remove publicIPAddress", a.RescourceGroupName, a.NicName, a.NamePublicIP, a.NicName)
+	captured = capture()
+	operate("az", arguments)
+	_, err = captured()
+	checkError(err)
+
+	// delete ip
+	fmt.Println("")
+	fmt.Println("  (3/3) Delete public ip")
+	arguments = fmt.Sprintf("az network public-ip delete -g %s -n %s", a.RescourceGroupName, a.NamePublicIP)
+	captured = capture()
+	operate("az", arguments)
+	_, err = captured()
+	checkError(err)
+	fmt.Println("")
+	fmt.Println("Configuration successfully cleaned up.")
+}

--- a/pkg/cmd/ssh_gcp.go
+++ b/pkg/cmd/ssh_gcp.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver"
+)
+
+// GCPInstanceAttribute stores all the critical information for creating an instance on GCP.
+type GCPInstanceAttribute struct {
+	ShootName                   string
+	BastionHostName             string
+	BastionHostFirewallRuleName string
+	BastionIP                   string
+	FirewallRuleName            string
+	VpcName                     string
+	Subnetwork                  string
+	UserData                    []byte
+	SSHPublicKey                []byte
+}
+
+// sshToGCPNode provides cmds to ssh to gcp via a public ip and clean it up afterwards
+func sshToGCPNode(nodeIP, path, user string, sshPublicKey []byte) {
+	g := &GCPInstanceAttribute{}
+	g.SSHPublicKey = sshPublicKey
+	fmt.Println("")
+
+	fmt.Println("(1/4) Fetching data from target shoot cluster")
+	g.fetchGCPAttributes(nodeIP, path)
+	fmt.Println("Data fetched from target shoot cluster.")
+	fmt.Println("")
+
+	fmt.Println("(2/4) Setting up bastion host firewall rule")
+	g.createBastionHostFirewallRule()
+	fmt.Println("")
+
+	fmt.Println("(3/4) Creating bastion host")
+	g.createBastionHostInstance()
+
+	bastionNode := user + "@" + g.BastionIP
+	node := user + "@" + nodeIP
+	fmt.Println("Waiting 45 seconds until ports are open.")
+	time.Sleep(45 * time.Second)
+
+	sshCmd := fmt.Sprintf("ssh -i key -o \"ProxyCommand ssh -W %%h:%%p -i key -o StrictHostKeyChecking=no " + bastionNode + "\" " + node + " -o StrictHostKeyChecking=no")
+	fmt.Println(sshCmd)
+	cmd := exec.Command("bash", "-c", sshCmd)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	checkError(err)
+
+	fmt.Println("(4/4) Cleanup")
+	g.cleanupGcpBastionHost()
+}
+
+// fetchAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeIP>.
+func (g *GCPInstanceAttribute) fetchGCPAttributes(nodeIP, path string) {
+	var err error
+	g.ShootName = getShootClusterName()
+	g.BastionHostName = g.ShootName + "-bastions"
+	g.BastionHostFirewallRuleName = g.ShootName + "-fw"
+	g.Subnetwork = g.ShootName + "-nodes"
+	terraformVersion, err := ExecCmdReturnOutput("bash", "-c", "cat "+path+"  | jq -r .terraform_version")
+	checkError(err)
+	c, err := semver.NewConstraint(">= 0.12.0")
+	if err != nil {
+		fmt.Println("Handle version not being parsable.")
+		os.Exit(2)
+	}
+	v, err := semver.NewVersion(terraformVersion)
+	if err != nil {
+		fmt.Println("Handle version not being parsable.")
+		os.Exit(2)
+	}
+	if c.Check(v) {
+		fmt.Println(path)
+		//g.FirewallRuleName, err = ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r .resources[\"google_compute_firewall.rule-allow-external-access\"].primary[\"id\"]''")
+		g.FirewallRuleName, err = ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r '.resources[] | select(.name == \"rule-allow-external-access\").instances[0].attributes.id'")
+		checkError(err)
+		g.VpcName, err = ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r '.outputs.vpc_name.value'")
+		checkError(err)
+	} else {
+		g.FirewallRuleName, err = ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r '.modules[].resources[\"google_compute_firewall.rule-allow-external-access\"].primary[\"id\"]''")
+		checkError(err)
+		g.VpcName, err = ExecCmdReturnOutput("bash", "-c", "cat "+path+" | jq -r '.modules[].outputs.vpc_name.value'")
+		checkError(err)
+	}
+	g.UserData = getBastionUserData(g.SSHPublicKey)
+}
+
+// createBastionHostFirewallRule finds the or creates a security group for the bastion host.
+func (g *GCPInstanceAttribute) createBastionHostFirewallRule() {
+	var err error
+	fmt.Println("Add ssh rule")
+	arguments := "gcloud " + fmt.Sprintf("compute firewall-rules update %s --allow tcp:22,tcp:80,tcp:443", g.FirewallRuleName)
+	captured := capture()
+	operate("gcp", arguments)
+	capturedOutput, err := captured()
+	checkError(err)
+	fmt.Println(capturedOutput)
+}
+
+// createBastionHostInstance finds or creates a bastion host instance.
+func (g *GCPInstanceAttribute) createBastionHostInstance() {
+	fmt.Println("Create bastion host")
+
+	tmpfile, err := ioutil.TempFile(os.TempDir(), "gardener-user.sh")
+	checkError(err)
+	defer os.Remove(tmpfile.Name())
+	_, err = tmpfile.Write(g.UserData)
+	checkError(err)
+
+	arguments := fmt.Sprintf("gcloud compute instances create %s --network %s --subnet %s --metadata-from-file startup-script=%s", g.BastionHostName, g.VpcName, g.Subnetwork, tmpfile.Name())
+	captured := capture()
+	operate("gcp", arguments)
+	capturedOutput, err := captured()
+	checkError(err)
+	fmt.Println(capturedOutput)
+
+	// check if bastion host is up and running, timeout after 3 minutes
+	attemptCnt := 0
+	for attemptCnt < 60 {
+		arguments = fmt.Sprintf("gcloud compute instances describe %s --flatten=[status]", g.BastionHostName)
+		captured = capture()
+		operate("gcp", arguments)
+		capturedOutput, err = captured()
+		capturedOutput = strings.Trim(capturedOutput, "-\n ")
+		checkError(err)
+		fmt.Println("Instance State: " + capturedOutput)
+		if strings.Trim(capturedOutput, "\n") == "RUNNING" {
+			arguments := fmt.Sprintf("gcloud compute instances describe %s --flatten=networkInterfaces[0].accessConfigs[0].natIP", g.BastionHostName)
+			captured := capture()
+			operate("gcp", arguments)
+			capturedOutput, err := captured()
+			capturedOutput = strings.Trim(capturedOutput, "-\n ")
+			words := strings.Fields(capturedOutput)
+			checkError(err)
+			ip := ""
+			for _, value := range words {
+				if isIP(value) && !strings.HasPrefix(value, "10.") {
+					ip = value
+					break
+				}
+			}
+			g.BastionIP = ip
+			return
+		}
+		time.Sleep(time.Second * 2)
+		attemptCnt++
+	}
+	if attemptCnt == 90 {
+		fmt.Println("Bastion server instance timeout. Please try again.")
+		os.Exit(2)
+	}
+
+}
+
+// cleanupGcpBastionHost cleans up the bastion host for the targeted cluster.
+func (g *GCPInstanceAttribute) cleanupGcpBastionHost() {
+	fmt.Println("Cleaning up bastion host configurations...")
+	fmt.Println("")
+	fmt.Println("Starting cleanup")
+	fmt.Println("")
+
+	// clean up bastion host instance
+	fmt.Println("  (1/2) Cleaning up bastion host instance")
+	arguments := fmt.Sprintf("gcloud --quiet compute instances delete %s", g.BastionHostName)
+	captured := capture()
+	operate("gcp", arguments)
+	capturedOutput, err := captured()
+	checkError(err)
+	fmt.Println(capturedOutput)
+
+	// remove shh port from firewall rule
+	fmt.Println("  (2/2) Close SSH Port on Node.")
+	fmt.Println("Close SSH Port on Node.")
+	arguments = "gcloud " + fmt.Sprintf("compute firewall-rules update %s --allow tcp:80,tcp:443", g.FirewallRuleName)
+	captured = capture()
+	operate("gcp", arguments)
+	capturedOutput, err = captured()
+	checkError(err)
+	fmt.Println(capturedOutput)
+	fmt.Println("Bastion host configurations successfully cleaned up.")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Automates ssh cmd for aws, azure and gcp.
- Splits ssh cmd into separate files to make it more readable
- Read ssh config from garden cluster
- Print warning when entering untrusted zone

Fixes: 
- https://github.com/gardener/gardenctl/issues/73
- https://github.com/gardener/gardenctl/issues/123
- https://github.com/gardener/gardenctl/issues/126

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
- Improved ssh cmd for aws, azure and gcp
```
