### PR TITLE
Restrict kubeconfig authentication info to prevent dark side of kubeconfig hack

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -80,9 +80,11 @@ github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/pkg/cmd/miscellaneous.go
+++ b/pkg/cmd/miscellaneous.go
@@ -104,12 +104,18 @@ func clientToTarget(target TargetKind) (*k8s.Clientset, error) {
 		err := flag.Set("kubeconfig", KUBECONFIG)
 		checkError(err)
 	}
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	kubeconfig, err := ioutil.ReadFile(*kubeconfig)
 	checkError(err)
-	// create the clientset
+	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+	checkError(err)
+	rawConfig, err := clientConfig.RawConfig()
+	checkError(err)
+	if err := ValidateClientConfig(rawConfig); err != nil {
+		return nil, err
+	}
+	config, err := clientConfig.ClientConfig()
+	checkError(err)
 	clientset, err := k8s.NewForConfig(config)
-	checkError(err)
 	return clientset, err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Referenced Kubeconfigs may now only contain the following keys as authentication info: `client-certificate-data`, `client-key-data`, `token`, `username`, or `password`.

**Which issue(s) this PR fixes**:
Fixes #136

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
For kubeconfig authentication only the following keys: `client-certificate-data`, `client-key-data`, `token`, `username`, or `password` are allowed.
```
