### PR TITLE
Read email from config for register/unregister cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ First clone the repository as described in the the build step "From source". As 
 
 Here an example file:
 ``` yaml
+email: john.doe@example.com
 githubURL: https://github.location.company.corp
 gardenClusters:
 - name: dev

--- a/pkg/cmd/miscellaneous.go
+++ b/pkg/cmd/miscellaneous.go
@@ -264,6 +264,12 @@ func getEmail(githubURL string) string {
 	return res
 }
 
+func getEmailFromConfig() string {
+	var gardenConfig GardenConfig
+	GetGardenConfig(pathGardenConfig, &gardenConfig)
+	return gardenConfig.Email
+}
+
 func getGithubURL() string {
 	var gardenConfig GardenConfig
 	GetGardenConfig(pathGardenConfig, &gardenConfig)

--- a/pkg/cmd/register.go
+++ b/pkg/cmd/register.go
@@ -64,6 +64,7 @@ func NewRegisterCmd() *cobra.Command {
 				email = args[0]
 			}
 			if len(args) < 1 {
+				email = getEmailFromConfig()
 				githubURL := getGithubURL()
 				if email == "" {
 					if githubURL == "" {

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -119,6 +119,7 @@ type GardenConfigReader struct{}
 
 //GardenConfig contains config for gardenctl
 type GardenConfig struct {
+	Email          string              `yaml:"email,omitempty" json:"email,omitempty"`
 	GithubURL      string              `yaml:"githubURL,omitempty" json:"githubURL,omitempty"`
 	GardenClusters []GardenClusterMeta `yaml:"gardenClusters,omitempty" json:"gardenClusters,omitempty"`
 }

--- a/pkg/cmd/unregister.go
+++ b/pkg/cmd/unregister.go
@@ -58,6 +58,7 @@ func NewUnregisterCmd() *cobra.Command {
 				email = args[0]
 			}
 			if len(args) < 1 {
+				email = getEmailFromConfig()
 				githubURL := getGithubURL()
 				if email == "" {
 					if githubURL == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
E-mail can now also be read from config for register/unregister cmd.

Precedence order, starting with highest precedence:
1. Specified e-mail as argument
2. Specified e-mail in config
3. Read from github URL

Sample configuration:

 ``` yaml
email: john.doe@example.com
 githubURL: https://github.location.company.corp
 gardenClusters:
 - name: dev
```

**Which issue(s) this PR fixes**:
Fixes #124 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
E-mail can now also be read from config for register/unregister cmd.

```
