### PR TITLE
Tag all infra resources created by gardenctl

### DIFF
--- a/pkg/cmd/ssh_aws.go
+++ b/pkg/cmd/ssh_aws.go
@@ -165,6 +165,8 @@ func (a *AwsInstanceAttribute) createBastionHostSecurityGroup() {
 	capturedOutput, err := captured()
 	checkError(err)
 	a.BastionSecurityGroupID = strings.Trim((capturedOutput), "\n")
+	arguments = fmt.Sprintf("aws ec2 create-tags --resources %s  --tags Key=component,Value=gardenctl", a.BastionSecurityGroupID)
+	operate("aws", arguments)
 	arguments = fmt.Sprintf("aws ec2 authorize-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr 0.0.0.0/0", a.BastionSecurityGroupID)
 	operate("aws", arguments)
 	fmt.Println("Bastion host security group set up.")
@@ -225,7 +227,7 @@ func (a *AwsInstanceAttribute) createBastionHostInstance() {
 	checkError(err)
 
 	// create bastion host
-	arguments := "aws " + fmt.Sprintf("ec2 run-instances --iam-instance-profile Name=%s --image-id %s --count 1 --instance-type t2.nano --key-name %s --security-group-ids %s --subnet-id %s --associate-public-ip-address --user-data file://%s --tag-specifications ResourceType=instance,Tags=[{Key=Name,Value=%s}]", a.BastionInstanceName, a.ImageID, a.KeyName, a.BastionSecurityGroupID, a.SubnetID, tmpfile.Name(), a.BastionInstanceName)
+	arguments := "aws " + fmt.Sprintf("ec2 run-instances --iam-instance-profile Name=%s --image-id %s --count 1 --instance-type t2.nano --key-name %s --security-group-ids %s --subnet-id %s --associate-public-ip-address --user-data file://%s --tag-specifications ResourceType=instance,Tags=[{Key=Name,Value=%s},{Key=component,Value=gardenctl}] ResourceType=volume,Tags=[{Key=component,Value=gardenctl}]", a.BastionInstanceName, a.ImageID, a.KeyName, a.BastionSecurityGroupID, a.SubnetID, tmpfile.Name(), a.BastionInstanceName)
 	captured := capture()
 	operate("aws", arguments)
 	capturedOutput, err := captured()

--- a/pkg/cmd/ssh_azure.go
+++ b/pkg/cmd/ssh_azure.go
@@ -146,7 +146,7 @@ func (a *AzureInstanceAttribute) addNsgRule() {
 func (a *AzureInstanceAttribute) createPublicIP() {
 	var err error
 	fmt.Println("Create public ip")
-	arguments := fmt.Sprintf("az network public-ip create -g %s -n %s --sku %s --allocation-method static", a.RescourceGroupName, a.NamePublicIP, a.SkuType)
+	arguments := fmt.Sprintf("az network public-ip create -g %s -n %s --sku %s --allocation-method static --tags component=gardenctl", a.RescourceGroupName, a.NamePublicIP, a.SkuType)
 	captured := capture()
 	operate("az", arguments)
 	a.PublicIP, err = captured()


### PR DESCRIPTION
**What this PR does / why we need it**:
Tag all infrastructure resources created by gardenctl.
Currently implementation supports tagging for aws, azure and gcp.

**Which issue(s) this PR fixes**:
Fixes #141 

**Special notes for your reviewer**:
Currently all created resources are tagged but not the updated ones.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Tag all infrastructure resources created by gardenctl for aws, azure and gcp.
```
