### PR TITLE
fix minor issue for cleanup tips of alicloud bastion host

### DIFF
--- a/pkg/cmd/ssh_alicloud.go
+++ b/pkg/cmd/ssh_alicloud.go
@@ -135,7 +135,7 @@ func sshToAlicloudNode(nodeName, path, user string, sshPublicKey []byte) {
 		fmt.Println("gardenctl aliyun ecs StopInstance -- --InstanceId=" + a.BastionInstanceID)
 		fmt.Println("")
 		fmt.Println("- Run following command before shoot deletion:")
-		fmt.Println("gardenctl ssh clean")
+		fmt.Println("gardenctl ssh cleanup")
 	default:
 		fmt.Println("Unknown option")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix cleanup tips of ssh to alicloud Shoot. Change from `gardenctl ssh clean` to `gardenctl ssh cleanup`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Hi, I just noticed that using gardener user to ssh to Alicloud bastion host & Shoot node has already been implemented. Thanks for the effort! I find this small output issue that you missed when you updated the feature.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
