### PR TITLE
Improve SSH check

### DIFF
--- a/pkg/cmd/ssh_aws.go
+++ b/pkg/cmd/ssh_aws.go
@@ -63,6 +63,8 @@ func sshToAWSNode(nodeName, path, user string, sshPublicKey []byte) {
 	a.createBastionHostSecurityGroup()
 	fmt.Println("")
 
+	defer a.cleanupAwsBastionHost()
+
 	fmt.Println("(3/4) Creating bastion host")
 	a.createBastionHostInstance()
 
@@ -76,11 +78,9 @@ func sshToAWSNode(nodeName, path, user string, sshPublicKey []byte) {
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	checkError(err)
-
-	fmt.Println("(4/4) Cleanup")
-	a.cleanupAwsBastionHost()
+	if err := cmd.Run(); err != nil {
+		fmt.Println(err)
+	}
 }
 
 // fetchAwsAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName>.
@@ -300,6 +300,7 @@ func getAWSMachineClasses() *v1alpha1.AWSMachineClassList {
 
 // cleanupAwsBastionHost cleans up the bastion host for the targeted cluster.
 func (a *AwsInstanceAttribute) cleanupAwsBastionHost() {
+	fmt.Println("(4/4) Cleanup")
 	fmt.Println("Cleaning up bastion host configurations...")
 	fmt.Println("")
 	fmt.Println("Starting cleanup")

--- a/pkg/cmd/ssh_azure.go
+++ b/pkg/cmd/ssh_azure.go
@@ -54,6 +54,8 @@ func sshToAZNode(nodeName, path, user string, sshPublicKey []byte) {
 	a.addNsgRule()
 	fmt.Println("")
 
+	defer a.cleanupAzure()
+
 	// create public ip
 	a.createPublicIP()
 	fmt.Println("Waiting 5 s until public ip is available.")
@@ -74,12 +76,9 @@ func sshToAZNode(nodeName, path, user string, sshPublicKey []byte) {
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	checkError(err)
-
-	fmt.Println("")
-	fmt.Println("(4/4) Cleanup")
-	a.cleanupAzure()
+	if err := cmd.Run(); err != nil {
+		fmt.Println(err)
+	}
 }
 
 // fetchAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName>.
@@ -193,6 +192,9 @@ func fetchAzureMachineNameByNodeName(shootName, nodeName string) (string, error)
 
 // cleanupAzure cleans up all created azure resources required for ssh connection
 func (a *AzureInstanceAttribute) cleanupAzure() {
+	fmt.Println("")
+	fmt.Println("(4/4) Cleanup")
+
 	var err error
 
 	// remove ssh rule

--- a/pkg/cmd/ssh_gcp.go
+++ b/pkg/cmd/ssh_gcp.go
@@ -58,6 +58,8 @@ func sshToGCPNode(nodeName, path, user string, sshPublicKey []byte) {
 	g.createBastionHostFirewallRule()
 	fmt.Println("")
 
+	defer g.cleanupGcpBastionHost()
+
 	fmt.Println("(3/4) Creating bastion host")
 	g.createBastionHostInstance()
 
@@ -72,11 +74,9 @@ func sshToGCPNode(nodeName, path, user string, sshPublicKey []byte) {
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	checkError(err)
-
-	fmt.Println("(4/4) Cleanup")
-	g.cleanupGcpBastionHost()
+	if err := cmd.Run(); err != nil {
+		fmt.Println(err)
+	}
 }
 
 // fetchAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName>.
@@ -231,6 +231,7 @@ func fetchZone(shootName, nodeName string) (string, error) {
 
 // cleanupGcpBastionHost cleans up the bastion host for the targeted cluster.
 func (g *GCPInstanceAttribute) cleanupGcpBastionHost() {
+	fmt.Println("(4/4) Cleanup")
 	fmt.Println("Cleaning up bastion host configurations...")
 	fmt.Println("")
 	fmt.Println("Starting cleanup")


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if we have node which can not join the cluster, the MCM will wait 20 min and after that will replace it with new one. During this time if we are `ssh` on this node, the `cmd.Run()` will crash with error and `checkError(err)` will terminate the function before the created resources are being deleted (We do not want this to happen).

So this PR fixes this scenario. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@DockToFuture 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
