### PR TITLE
Target shoot without an available kubeconfig

### DIFF
--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -517,7 +517,9 @@ func targetShoot(targetWriter TargetWriter, shoot gardencorev1alpha1.Shoot) {
 	// Get shoot kubeconfig
 	var shootKubeconfigSecretName = fmt.Sprintf("%s.kubeconfig", shoot.Name)
 	shootKubeconfigSecret, err := gardenClient.CoreV1().Secrets(shoot.Namespace).Get(shootKubeconfigSecretName, metav1.GetOptions{})
-	checkError(err)
+	if err != nil {
+		fmt.Println("Kubeconfig not available, using empty one. Be aware only a limited number of cmds are available!")
+	}
 
 	k8sClientToGarden, err := target.K8SClientToKind(TargetKindGarden)
 	checkError(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
When targeting a shoot and kubeconfig is not available, use empty one to allow limited set of cmds on shoot.
**Which issue(s) this PR fixes**:
Fixes #132 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
none
```
