### PR TITLE
Fix CODEOWNERS syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,2 @@
 # gardenctl maintainers
-*   @DockToFuture
-*   @ialidzhikov
+*   @DockToFuture @ialidzhikov


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this PR:
```
$ REPOSITORY_PATH="." OWNER_CHECKER_ORGANIZATION_NAME="gardener" codeowners-validator
==> Executing Duplicated Pattern Checker (1.150649ms)
    [err] Pattern "*" is defined 2 times in lines:
            * 2: with owners: [@DockToFuture]
            * 3: with owners: [@ialidzhikov]
==> Executing File Exist Checker (1.20347ms)
    Check OK
==> Executing Valid Owner Checker (961.927132ms)
    Check OK

3 check(s) executed, 1 failure(s)
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
