### PR TITLE
Update administrators ClusterRoleBinding name

### DIFF
--- a/pkg/cmd/register.go
+++ b/pkg/cmd/register.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// AdminClusterRoleBindingName is the name for the administrator ClusterRoleBinding
-	AdminClusterRoleBindingName = "garden.sapcloud.io:system:administrators"
+	AdminClusterRoleBindingName = "gardener.cloud:system:administrators"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
gardener/gardener#1601 renames `garden.sapcloud.io:system:administrators` to `gardener.cloud:system:administrators`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
