### PR TITLE
add target flags

### DIFF
--- a/pkg/cmd/download.go
+++ b/pkg/cmd/download.go
@@ -68,7 +68,7 @@ func downloadTerraformFiles(option string) string {
 		fmt.Println("No Shoot targeted")
 		os.Exit(2)
 	} else if len(target.Stack()) < 3 {
-		fmt.Println("Command must be in the format:\n  download tf + (infra|internal-dns|external-dns|ingress|backup)\n  download logs vpn")
+		fmt.Println("Command must be in the format:\n download tf + (infra|internal-dns|external-dns|ingress|backup)\n  download logs vpn")
 		os.Exit(2)
 	} else {
 		var err error

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -122,6 +122,7 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolVarP(&cachevar, "no-cache", "n", false, "no caching")
 	RootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "yaml", "output format yaml or json")
+
 	cobra.EnableCommandSorting = false
 	cobra.EnablePrefixMatching = prefixMatching
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Target flags are added for garden, seed, project and shoot.
**Which issue(s) this PR fixes**:
Fixes  #143 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Target flags are added for garden, seed, project and shoot.
```
