### PR TITLE
Add sessions to gardenctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The path to the kubeconfig files of a garden cluster can be relative by using th
 
 `gardenctl` caches some information, e.g. the garden project names. The location of this cache is per default `$GARDENCTL_HOME/cache`. If `GARDENCTL_HOME` is not set, `~/.garden` is assumed.
 
+`gardenctl` supports multiple sessions. The session ID can be set via `$GARDEN_SESSION_ID` and the sessions are stored under `$GARDENCTL_HOME/sessions`.
+
 `gardenctl` makes it easy to get additional information of your IaaS provider by using the secrets stored in the corresponding projects in the Gardener. To use this functionality, the CLIs of the IaaS providers need to be available. 
 
 Please check the IaaS provider documentation for more details about their CLIs.

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -30,6 +30,7 @@ var cachevar bool
 var outputFormat string
 var gardenConfig string
 var pathGardenHome string
+var sessionID string
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -90,8 +91,14 @@ func Execute() {
 		pathGardenHome = strings.Replace(pathGardenHome, "~", HomeDir(), 1)
 	}
 	pathGardenConfig = filepath.Join(pathGardenHome, "config")
-	pathTarget = filepath.Join(pathGardenHome, "target")
 	CreateDir(pathGardenHome, 0751)
+	sessionID = os.Getenv("GARDEN_SESSION_ID")
+	if sessionID == "" {
+		sessionID = "plantingSession"
+	}
+	pathSessionID := filepath.Join(pathDefaultSession, sessionID)
+	CreateDir(pathSessionID, 0751)
+	pathTarget = filepath.Join(pathSessionID, "target")
 	CreateFileIfNotExists(pathTarget, 0644)
 	gardenConfig = os.Getenv("GARDENCONFIG")
 	if gardenConfig != "" {
@@ -171,6 +178,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.
 
 Configuration and KUBECONFIG file cache located $GARDENCTL_HOME or ~/.garden (default).
 Gardenctl configuration file must be provided in $GARDENCONFIG or ~/.garden/config (default).
+Session ID can be specified via $GARDEN_SESSION_ID.
 
 Find more information and an example configuration at https://github.com/gardener/gardenctl
 {{end}}

--- a/pkg/cmd/var.go
+++ b/pkg/cmd/var.go
@@ -42,7 +42,8 @@ var (
 	password string
 
 	// file pathes
-	pathGardenConfig string
-	pathTarget       string
-	pathDefault      = filepath.Join(HomeDir(), ".garden")
+	pathGardenConfig   string
+	pathTarget         string
+	pathDefault        = filepath.Join(HomeDir(), ".garden")
+	pathDefaultSession = filepath.Join(HomeDir(), ".garden", "sessions")
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Sessions are added to `gardenctl`. This allows to operate on multiple clusters at the same time in different terminal sessions which was not possible before. The session ID can be set via the `GARDEN_SESSION_ID` environment variable.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Sessions are added to `gardenctl`. This allows to operate on multiple clusters at the same time in different terminal sessions which was not possible before. The session ID can be set via the `GARDEN_SESSION_ID` environment variable.
```
