### PR TITLE
issue-161, move key from current dir to shoot cache

### DIFF
--- a/pkg/cmd/ssh.go
+++ b/pkg/cmd/ssh.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -67,8 +66,18 @@ func NewSSHCmd(reader TargetReader, ioStreams IOStreams) *cobra.Command {
 			fmt.Printf(warningColor, "\nWarning:\nBe aware that you are entering an untrusted environment!\nDo not enter credentials or sensitive data within the ssh session that cluster owners should not have access to.\n")
 			fmt.Println("")
 
+			gardenName := target.Stack()[0].Name
+			shootName := target.Stack()[2].Name
+			var pathSSKeypair string
+			if target.Stack()[1].Kind == TargetKindProject {
+				projectName := target.Stack()[1].Name
+				pathSSKeypair = filepath.Join(pathGardenHome, "cache", gardenName, "projects", projectName, shootName)
+			} else {
+				seedName := target.Stack()[1].Name
+				pathSSKeypair = filepath.Join(pathGardenHome, "cache", gardenName, "seeds", seedName, shootName)
+			}
+
 			sshKeypairSecret := getSSHKeypair(shoot)
-			pathSSKeypair, err := os.Getwd()
 			checkError(err)
 			err = ioutil.WriteFile(filepath.Join(pathSSKeypair, "key"), sshKeypairSecret.Data["id_rsa"], 0600)
 			checkError(err)


### PR DESCRIPTION
this is for https://github.com/gardener/gardenctl/issues/161

currently when using `gardenctl ssh node_name` the key is downloaded in current dir.
Per suggestion from https://github.com/gardener/gardenctl/issues/161#issuecomment-583126960 moving key to shoot cache dir