### PR TITLE
issue 160 - add upgrade notification when new version available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.3.1
 	github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e
+	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,8 @@ github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HN
 github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.0-20190805055040-f9202b1cfdeb/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 h1:YocNLcTBdEdvY3iDK6jfWXvEaM5OCKkjxPKoJRdB3Gg=
+github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2/go.mod h1:76rfSfYPWj01Z85hUf/ituArm797mNKcvINh1OlsZKo=
 github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/vendor/github.com/mcuadros/go-version/.gitignore
+++ b/vendor/github.com/mcuadros/go-version/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/mcuadros/go-version/.travis.yml
+++ b/vendor/github.com/mcuadros/go-version/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/vendor/github.com/mcuadros/go-version/LICENSE
+++ b/vendor/github.com/mcuadros/go-version/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Máximo Cuadros
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mcuadros/go-version/README.md
+++ b/vendor/github.com/mcuadros/go-version/README.md
@@ -1,0 +1,80 @@
+go-version [![Build Status](https://travis-ci.org/mcuadros/go-version.svg?branch=master)](https://travis-ci.org/mcuadros/go-version) [![GoDoc](https://godoc.org/github.com/mcuadros/go-version?status.svg)](http://godoc.org/github.com/mcuadros/go-version)
+==============================
+
+Version normalizer and comparison library for go, heavy based on PHP version_compare function and Version comparsion libs from [Composer](https://github.com/composer/composer) PHP project
+
+Installation
+------------
+
+The recommended way to install go-version
+
+```
+go get github.com/mcuadros/go-version
+```
+
+Examples
+--------
+
+How import the package
+
+```go
+import (
+    "github.com/mcuadros/go-version"
+)
+```
+
+`version.Normalize()`: Normalizes a version string to be able to perform comparisons on it
+
+```go
+version.Normalize("10.4.13-b")
+//Returns: 10.4.13.0-beta
+```
+
+
+`version.CompareSimple()`: Compares two normalizated version number strings
+
+```go
+version.CompareSimple("1.2", "1.0.1")
+//Returns: 1
+
+version.CompareSimple("1.0rc1", "1.0")
+//Returns: -1
+```
+
+
+`version.Compare()`: Compares two normalizated version number strings, for a particular relationship
+
+```go
+version.Compare("1.0-dev", "1.0", "<")
+//Returns: true
+
+version.Compare("1.0rc1", "1.0", ">=")
+//Returns: false
+
+version.Compare("2.3.4", "v3.1.2", "<")
+//Returns: true
+```
+
+`version.ConstrainGroup.Match()`: Match a given version againts a group of constrains, read about constraint string format at [Composer documentation](http://getcomposer.org/doc/01-basic-usage.md#package-versions)  
+
+```go
+c := version.NewConstrainGroupFromString(">2.0,<=3.0")
+c.Match("2.5.0beta")
+//Returns: true
+
+c := version.NewConstrainGroupFromString("~1.2.3")
+c.Match("1.2.3.5")
+//Returns: true
+```
+
+`version.Sort()`: Sorts a string slice of version number strings using version.CompareSimple()
+
+```go
+version.Sort([]string{"1.10-dev", "1.0rc1", "1.0", "1.0-dev"})
+//Returns []string{"1.0-dev", "1.0rc1", "1.0", "1.10-dev"}
+```
+
+License
+-------
+
+MIT, see [LICENSE](LICENSE)

--- a/vendor/github.com/mcuadros/go-version/compare.go
+++ b/vendor/github.com/mcuadros/go-version/compare.go
@@ -1,0 +1,173 @@
+package version
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var regexpSigns = regexp.MustCompile(`[_\-+]`)
+var regexpDotBeforeDigit = regexp.MustCompile(`([^.\d]+)`)
+var regexpMultipleDots = regexp.MustCompile(`\.{2,}`)
+
+var specialForms = map[string]int{
+	"SNAPSHOT": -7,
+	"snapshot": -7,
+	"dev":      -6,
+	"alpha":    -5,
+	"a":        -5,
+	"beta":     -4,
+	"b":        -4,
+	"RC":       -3,
+	"rc":       -3,
+	"#":        -2,
+	"p":        1,
+	"pl":       1,
+}
+
+var unknownForm int = -7
+
+// Compare compares two version number strings, for a particular relationship
+//
+// Usage
+//     version.Compare("2.3.4", "v3.1.2", "<")
+//     Returns: true
+//
+//     version.Compare("1.0rc1", "1.0", ">=")
+//     Returns: false
+func Compare(version1, version2, operator string) bool {
+	version1N := Normalize(version1)
+	version2N := Normalize(version2)
+
+	return CompareNormalized(version1N, version2N, operator)
+}
+
+// CompareNormalized compares two normalizated version number strings, for a particular relationship
+//
+// The function first replaces _, - and + with a dot . in the version strings
+// and also inserts dots . before and after any non number so that for example
+// '4.3.2RC1' becomes '4.3.2.RC.1'.
+//
+// Then it splits the results like if you were using Split(version, '.').
+// Then it compares the parts starting from left to right. If a part contains
+// special version strings these are handled in the following order: any string
+// not found in this list:
+//   < dev < alpha = a < beta = b < RC = rc < # < pl = p.
+//
+// Usage
+//     version.CompareNormalized("1.0-dev", "1.0", "<")
+//     Returns: true
+//
+//     version.CompareNormalized("1.0rc1", "1.0", ">=")
+//     Returns: false
+//
+//     version.CompareNormalized("1.0", "1.0b1", "ge")
+//     Returns: true
+func CompareNormalized(version1, version2, operator string) bool {
+	compare := CompareSimple(version1, version2)
+
+	switch {
+	case operator == ">" || operator == "gt":
+		return compare > 0
+	case operator == ">=" || operator == "ge":
+		return compare >= 0
+	case operator == "<=" || operator == "le":
+		return compare <= 0
+	case operator == "==" || operator == "=" || operator == "eq":
+		return compare == 0
+	case operator == "<>" || operator == "!=" || operator == "ne":
+		return compare != 0
+	case operator == "" || operator == "<" || operator == "lt":
+		return compare < 0
+	}
+
+	return false
+}
+
+// CompareSimple compares two normalizated version number strings
+//
+// Just the same of CompareVersion but return a int result, 0 if both version
+// are equal, 1 if the right side is bigger and -1 if the right side is lower
+//
+// Usage
+//     version.CompareSimple("1.2", "1.0.1")
+//     Returns: 1
+//
+//     version.CompareSimple("1.0rc1", "1.0")
+//     Returns: -1
+func CompareSimple(version1, version2 string) int {
+	var x, r, l int = 0, 0, 0
+
+	v1, v2 := prepVersion(version1), prepVersion(version2)
+	len1, len2 := len(v1), len(v2)
+
+	if len1 > len2 {
+		x = len1
+	} else {
+		x = len2
+	}
+
+	for i := 0; i < x; i++ {
+		if i < len1 && i < len2 {
+			if v1[i] == v2[i] {
+				continue
+			}
+		}
+
+		r = 0
+		if i < len1 {
+			r = numVersion(v1[i])
+		}
+
+		l = 0
+		if i < len2 {
+			l = numVersion(v2[i])
+		}
+
+		if r < l {
+			return -1
+		} else if r > l {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+func prepVersion(version string) []string {
+	if len(version) == 0 {
+		return []string{""}
+	}
+
+	version = regexpSigns.ReplaceAllString(version, ".")
+	version = regexpDotBeforeDigit.ReplaceAllString(version, ".$1.")
+	version = regexpMultipleDots.ReplaceAllString(version, ".")
+
+	return strings.Split(version, ".")
+}
+
+func numVersion(value string) int {
+	if value == "" {
+		return 0
+	}
+
+	if number, err := strconv.Atoi(value); err == nil {
+		return number
+	}
+
+	if special, ok := specialForms[value]; ok {
+		return special
+	}
+
+	return unknownForm
+}
+
+func ValidSimpleVersionFormat(value string) bool {
+	normalized := Normalize(value)
+	for _, component := range prepVersion(normalized) {
+		if numVersion(component) == unknownForm {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/mcuadros/go-version/constraint.go
+++ b/vendor/github.com/mcuadros/go-version/constraint.go
@@ -1,0 +1,49 @@
+package version
+
+import (
+	"strings"
+)
+
+type Constraint struct {
+	operator string
+	version  string
+}
+
+// NewConstrain returns a new Constrain and sets operator and version to compare
+func NewConstrain(operator, version string) *Constraint {
+	constraint := new(Constraint)
+	constraint.SetOperator(operator)
+	constraint.SetVersion(version)
+
+	return constraint
+}
+
+// Sets operator to compare
+func (self *Constraint) SetOperator(operator string) {
+	self.operator = operator
+}
+
+// GetOperator gets operator to compare
+func (self *Constraint) GetOperator() string {
+	return self.operator
+}
+
+// Sets version to compare
+func (self *Constraint) SetVersion(version string) {
+	self.version = version
+}
+
+// GetVersion gets version to compare
+func (self *Constraint) GetVersion() string {
+	return self.version
+}
+
+// Match a given version againts the constraint
+func (self *Constraint) Match(version string) bool {
+	return Compare(version, self.version, self.operator)
+}
+
+// String returns a string representation
+func (self *Constraint) String() string {
+	return strings.Trim(self.operator+" "+self.version, " ")
+}

--- a/vendor/github.com/mcuadros/go-version/doc.go
+++ b/vendor/github.com/mcuadros/go-version/doc.go
@@ -1,0 +1,6 @@
+/*
+Version normalizer and comparison library for go, heavy based on PHP 
+version_compare function and Version comparsion libs from Composer 
+(https://github.com/composer/composer) PHP project
+*/
+package version

--- a/vendor/github.com/mcuadros/go-version/group.go
+++ b/vendor/github.com/mcuadros/go-version/group.go
@@ -1,0 +1,300 @@
+package version
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+type ConstraintGroup struct {
+	constraints []*Constraint
+}
+
+// NewConstrainGroup returns a new NewConstrainGroup
+func NewConstrainGroup() *ConstraintGroup {
+	group := new(ConstraintGroup)
+
+	return group
+}
+
+// NewConstrainGroupFromString returns a new NewConstrainGroup and create the constraints based on a string
+//
+// Version constraints can be specified in a few different ways:
+//
+// Exact version: You can specify the exact version of a package, for 
+// example 1.0.2.
+//
+// Range: By using comparison operators you can specify ranges of valid versions. 
+// Valid operators are >, >=, <, <=, !=. An example range would be >=1.0. You can 
+// define multiple ranges, separated by a comma: >=1.0,<2.0.
+// 
+// Wildcard: You can specify a pattern with a * wildcard. 1.0.* is the equivalent 
+// of >=1.0,<1.1.
+//
+// Next Significant Release (Tilde Operator): The ~ operator is best explained by 
+// example: ~1.2 is equivalent to >=1.2,<2.0, while ~1.2.3 is equivalent to 
+// >=1.2.3,<1.3. As you can see it is mostly useful for projects respecting 
+// semantic versioning. A common usage would be to mark the minimum minor 
+// version you depend on, like ~1.2 (which allows anything up to, but not 
+// including, 2.0). Since in theory there should be no backwards compatibility 
+// breaks until 2.0, that works well. Another way of looking at it is that 
+// using ~ specifies a minimum version, but allows the last digit specified 
+// to go up.
+//
+// By default only stable releases are taken into consideration. If you would like 
+// to also get RC, beta, alpha or dev versions of your dependencies you can do so 
+// using stability flags. To change that for all packages instead of doing per 
+// dependency you can also use the minimum-stability setting.
+// 
+// From: http://getcomposer.org/doc/01-basic-usage.md#package-versions
+func NewConstrainGroupFromString(name string) *ConstraintGroup {
+	group := new(ConstraintGroup)
+	group.fromString(name)
+
+	return group
+}
+
+// AddConstraint adds a Contraint to the group
+func (self *ConstraintGroup) AddConstraint(constraint ...*Constraint) {
+	if self.constraints == nil {
+		self.constraints = make([]*Constraint, 0)
+	}
+
+	self.constraints = append(self.constraints, constraint...)
+}
+
+// GetConstraints returns all the constraints
+func (self *ConstraintGroup) GetConstraints() []*Constraint {
+	return self.constraints
+}
+
+// Match a given version againts the group
+//
+// Usage
+//     c := version.NewConstrainGroupFromString(">2.0,<=3.0")
+//     c.Match("2.5.0beta")
+//     Returns: true
+//
+//     c := version.NewConstrainGroupFromString("~1.2.3")
+//     c.Match("1.2.3.5")
+//     Returns: true
+func (self *ConstraintGroup) Match(version string) bool {
+	for _, constraint := range self.constraints {
+		if constraint.Match(version) == false {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (self *ConstraintGroup) fromString(constraint string) bool {
+	result := RegFind(`(?i)^([^,\s]*?)@(stable|RC|beta|alpha|dev)$`, constraint)
+	if result != nil {
+		constraint = result[1]
+		if constraint == "" {
+			constraint = "*"
+		}
+	}
+
+	result = RegFind(`(?i)^(dev-[^,\s@]+?|[^,\s@]+?\.x-dev)#.+$`, constraint)
+	if result != nil {
+		if result[1] != "" {
+			constraint = result[1]
+		}
+	}
+
+	constraints := RegSplit(`\s*,\s*`, strings.Trim(constraint, " "))
+
+	if len(constraints) > 1 {
+		for _, part := range constraints {
+			self.AddConstraint(self.parseConstraint(part)...)
+		}
+
+		return true
+	}
+
+	self.AddConstraint(self.parseConstraint(constraints[0])...)
+
+	return true
+}
+
+func (self *ConstraintGroup) parseConstraint(constraint string) []*Constraint {
+
+	stabilityModifier := ""
+
+	result := RegFind(`(?i)^([^,\s]+?)@(stable|RC|beta|alpha|dev)$`, constraint)
+	if result != nil {
+		constraint = result[1]
+		if result[2] != "stable" {
+			stabilityModifier = result[2]
+		}
+	}
+
+	result = RegFind(`^[x*](\.[x*])*$`, constraint)
+	if result != nil {
+		return make([]*Constraint, 0)
+	}
+
+	highVersion := ""
+	lowVersion := ""
+
+	result = RegFind(`(?i)^~(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.(\d+))?`+modifierRegex+`?$`, constraint)
+	if result != nil {
+		if len(result) > 4 && result[4] != "" {
+			last, _ := strconv.Atoi(result[3])
+			highVersion = result[1] + "." + result[2] + "." + strconv.Itoa(last+1) + ".0-dev"
+			lowVersion = result[1] + "." + result[2] + "." + result[3] + "." + result[4]
+		} else if len(result) > 3 && result[3] != "" {
+			last, _ := strconv.Atoi(result[2])
+			highVersion = result[1] + "." + strconv.Itoa(last+1) + ".0.0-dev"
+			lowVersion = result[1] + "." + result[2] + "." + result[3] + ".0"
+		} else {
+			last, _ := strconv.Atoi(result[1])
+			highVersion = strconv.Itoa(last+1) + ".0.0.0-dev"
+			if len(result) > 2 && result[2] != "" {
+				lowVersion = result[1] + "." + result[2] + ".0.0"
+			} else {
+				lowVersion = result[1] + ".0.0.0"
+			}
+		}
+
+		if len(result) > 5 && result[5] != "" {
+			lowVersion = lowVersion + "-" + expandStability(result[5])
+
+		}
+
+		if len(result) > 6 && result[6] != "" {
+			lowVersion = lowVersion + result[6]
+		}
+
+		if len(result) > 7 && result[7] != "" {
+			lowVersion = lowVersion + "-dev"
+		}
+
+		return []*Constraint{
+			{">=", lowVersion},
+			{"<", highVersion},
+		}
+	}
+
+	result = RegFind(`^(\d+)(?:\.(\d+))?(?:\.(\d+))?\.[x*]$`, constraint)
+	if result != nil {
+		if len(result) > 3 && result[3] != "" {
+			highVersion = result[1] + "." + result[2] + "." + result[3] + ".9999999"
+			if result[3] == "0" {
+				last, _ := strconv.Atoi(result[2])
+				lowVersion = result[1] + "." + strconv.Itoa(last-1) + ".9999999.9999999"
+			} else {
+				last, _ := strconv.Atoi(result[3])
+				lowVersion = result[1] + "." + result[2] + "." + strconv.Itoa(last-1) + ".9999999"
+			}
+
+		} else if len(result) > 2 && result[2] != "" {
+			highVersion = result[1] + "." + result[2] + ".9999999.9999999"
+			if result[2] == "0" {
+				last, _ := strconv.Atoi(result[1])
+				lowVersion = strconv.Itoa(last-1) + ".9999999.9999999.9999999"
+			} else {
+				last, _ := strconv.Atoi(result[2])
+				lowVersion = result[1] + "." + strconv.Itoa(last-1) + ".9999999.9999999"
+			}
+
+		} else {
+			highVersion = result[1] + ".9999999.9999999.9999999"
+			if result[1] == "0" {
+				return []*Constraint{{"<", highVersion}}
+			} else {
+				last, _ := strconv.Atoi(result[1])
+				lowVersion = strconv.Itoa(last-1) + ".9999999.9999999.9999999"
+			}
+		}
+
+		return []*Constraint{
+			{">", lowVersion},
+			{"<", highVersion},
+		}
+	}
+
+	// match operators constraints
+	result = RegFind(`^(<>|!=|>=?|<=?|==?)?\s*(.*)`, constraint)
+	if result != nil {
+		version := Normalize(result[2])
+
+		if stabilityModifier != "" && parseStability(version) == "stable" {
+			version = version + "-" + stabilityModifier
+		} else if result[1] == "<" {
+			match := RegFind(`(?i)-stable$`, result[2])
+			if match == nil {
+				version = version + "-dev"
+			}
+		}
+
+		if len(result) > 1 && result[1] != "" {
+			return []*Constraint{{result[1], version}}
+		} else {
+			return []*Constraint{{"=", version}}
+
+		}
+	}
+
+	return []*Constraint{{constraint, stabilityModifier}}
+}
+
+// PCRegMap : PreCompiled Regex Map
+type PCRegMap struct {
+	sync.RWMutex
+	m map[string]*regexp.Regexp
+}
+
+// MustCompile : to replace regexp.MustCompile in RegFind.
+func (p *PCRegMap) MustCompile(pattern string) *regexp.Regexp {
+	p.RLock()
+	ret, exist := p.m[pattern]
+	p.RUnlock()
+	if exist {
+		return ret
+	}
+	ret = regexp.MustCompile(pattern)
+	p.Lock()
+	p.m[pattern] = ret
+	p.Unlock()
+	return ret
+}
+
+var (
+	regexpCache *PCRegMap
+)
+
+func init() {
+	regexpCache = new(PCRegMap)
+	regexpCache.m = make(map[string]*regexp.Regexp)
+}
+
+func RegFind(pattern, subject string) []string {
+	reg := regexpCache.MustCompile(pattern)
+	matched := reg.FindAllStringSubmatch(subject, -1)
+
+	if matched != nil {
+		return matched[0]
+	}
+
+	return nil
+}
+
+func RegSplit(pattern, subject string) []string {
+	reg := regexp.MustCompile(pattern)
+	indexes := reg.FindAllStringIndex(subject, -1)
+
+	laststart := 0
+	result := make([]string, len(indexes)+1)
+
+	for i, element := range indexes {
+		result[i] = subject[laststart:element[0]]
+		laststart = element[1]
+	}
+
+	result[len(indexes)] = subject[laststart:len(subject)]
+	return result
+}

--- a/vendor/github.com/mcuadros/go-version/normalize.go
+++ b/vendor/github.com/mcuadros/go-version/normalize.go
@@ -1,0 +1,116 @@
+package version
+
+import (
+	"regexp"
+	"strings"
+)
+
+var modifierRegex = `[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)(?:[.-]?(\d+))?)?([.-]?dev)?`
+
+var regexpMasterLikeBranches = regexp.MustCompile(`^(?:dev-)?(?:master|trunk|default)$`)
+var regexpBranchNormalize = regexp.MustCompile(`(?i)^v?(\d+)(\.(?:\d+|[x*]))?(\.(?:\d+|[x*]))?(\.(?:\d+|[x*]))?$`)
+
+// Normalizes a version string to be able to perform comparisons on it
+//
+// Example:
+//     version.Normalize("10.4.13-b")
+//     Returns: 10.4.13.0-beta
+//
+func Normalize(version string) string {
+
+	// ignore aliases and just assume the alias is required instead of the source
+	result := RegFind(`^([^,\s]+) +as +([^,\s]+)$`, version)
+	if result != nil {
+		version = result[1]
+	}
+
+	// match master-like branches
+	if regexpMasterLikeBranches.MatchString(strings.ToLower(version)) {
+		return "9999999-dev"
+	}
+
+	if strings.HasPrefix(strings.ToLower(version), "dev-") {
+		return "dev-" + version[4:len(version)]
+	}
+
+	index := 0
+
+	// match classical versioning
+	result = RegFind(`(?i)^v?(\d{1,3})(\.\d+)?(\.\d+)?(\.\d+)?`+modifierRegex+`$`, version)
+	if result != nil {
+		version = ""
+		for _, val := range result[1:5] {
+			if val != "" {
+				version = version + val
+			} else {
+				version = version + ".0"
+			}
+		}
+
+		index = 5
+	} else {
+		// match date-based versioning
+		result = RegFind(`(?i)^v?(\d{4}(?:[.:-]?\d{2}){1,6}(?:[.:-]?\d{1,3})?)`+modifierRegex+`$`, version)
+		if result != nil {
+			version = regexp.MustCompile(`\D`).ReplaceAllString(result[1], "-")
+			index = 2
+		}
+	}
+
+	if index != 0 {
+		if result[index] != "" {
+			if result[index] == "stable" {
+				return version
+			}
+
+			version = version + "-" + expandStability(result[index])
+			if result[index+1] != "" {
+				version = version + result[index+1]
+			}
+		}
+
+		if result[index+2] != "" {
+			version = version + "-dev"
+		}
+
+		return version
+	}
+
+	result = RegFind(`(?i)(.*?)[.-]?dev$`, version)
+	if result != nil {
+		return normalizeBranch(result[1])
+	}
+
+	return version
+}
+
+func normalizeBranch(name string) string {
+	name = strings.Trim(name, " ")
+
+	if name == "master" || name == "trunk" || name == "default" {
+		return Normalize(name)
+	}
+
+	replace := strings.NewReplacer("*", "9999999", "x", "9999999")
+
+	matched := regexpBranchNormalize.FindAllStringSubmatch(name, -1)
+	if matched != nil {
+		name = ""
+		for _, val := range matched[0][1:5] {
+			if val != "" {
+				name = name + replace.Replace(val)
+			} else {
+				name = name + ".9999999"
+			}
+		}
+
+		return name + "-dev"
+
+	}
+
+	if strings.HasSuffix(strings.ToLower(name), "-dev") {
+		return name
+	}
+
+	return "dev-" + name
+}

--- a/vendor/github.com/mcuadros/go-version/sort.go
+++ b/vendor/github.com/mcuadros/go-version/sort.go
@@ -1,0 +1,36 @@
+package version
+
+import (
+	"sort"
+)
+
+// Sorts a string slice of version number strings using version.CompareSimple()
+//
+// Example:
+//     version.Sort([]string{"1.10-dev", "1.0rc1", "1.0", "1.0-dev"})
+//     Returns []string{"1.0-dev", "1.0rc1", "1.0", "1.10-dev"}
+//
+func Sort(versionStrings []string) {
+	versions := versionSlice(versionStrings)
+	sort.Sort(versions)
+}
+
+type versionSlice []string
+
+func (s versionSlice) Len() int {
+	return len(s)
+}
+
+func (s versionSlice) Less(i, j int) bool {
+	cmp := CompareSimple(Normalize(s[i]), Normalize(s[j]))
+	if cmp == 0 {
+		return s[i] < s[j]
+	}
+	return cmp < 0
+}
+
+func (s versionSlice) Swap(i, j int) {
+	tmp := s[j]
+	s[j] = s[i]
+	s[i] = tmp
+}

--- a/vendor/github.com/mcuadros/go-version/stability.go
+++ b/vendor/github.com/mcuadros/go-version/stability.go
@@ -1,0 +1,83 @@
+package version
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	Development = iota
+	Alpha
+	Beta
+	RC
+	Stable
+)
+
+func expandStability(stability string) string {
+	stability = strings.ToLower(stability)
+
+	switch stability {
+	case "a":
+		return "alpha"
+	case "b":
+		return "beta"
+	case "p":
+		return "patch"
+	case "pl":
+		return "patch"
+	case "rc":
+		return "RC"
+	}
+
+	return stability
+}
+
+func parseStability(version string) string {
+	version = regexp.MustCompile(`(?i)#.+$`).ReplaceAllString(version, " ")
+	version = strings.ToLower(version)
+
+	if strings.HasPrefix(version, "dev-") || strings.HasSuffix(version, "-dev") {
+		return "dev"
+	}
+
+	result := RegFind(`(?i)^v?(\d{1,3})(\.\d+)?(\.\d+)?(\.\d+)?`+modifierRegex+`$`, version)
+	if result != nil {
+		if len(result) > 3 {
+			return "dev"
+		}
+	}
+
+	if result[1] != "" {
+		if "beta" == result[1] || "b" == result[1] {
+			return "beta"
+		}
+		if "alpha" == result[1] || "a" == result[1] {
+			return "alpha"
+		}
+		if "rc" == result[1] {
+			return "RC"
+		}
+	}
+
+	return "stable"
+}
+
+func GetStability(version string) int {
+	result := RegFind(`(?i)(stable|RC|beta|alpha|dev)`, Normalize(version))
+	if len(result) == 0 {
+		return Stable
+	}
+
+	switch result[1] {
+	case "dev":
+		return Development
+	case "alpha":
+		return Alpha
+	case "beta":
+		return Beta
+	case "RC":
+		return RC
+	}
+
+	return Stable
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -97,6 +97,8 @@ github.com/jmoiron/jsonq
 github.com/json-iterator/go
 # github.com/konsorten/go-windows-terminal-sequences v1.0.2
 github.com/konsorten/go-windows-terminal-sequences
+# github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
+github.com/mcuadros/go-version
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables notification to end user when a new version of `gardenctl` is available while running `gardenctl version` command
**Which issue(s) this PR fixes**:
Fixes #

https://github.com/gardener/gardenctl/issues/160
**Special notes for your reviewer**:

1) i added "new version notification" to command `gardenctl version` as the value of `VERSION` is injected in `gardenctl version` command only
2) to compare version numbers (in gardenctl it's e.g. `v0.15.0` or `v0.16.0`) i use one library `github.com/mcuadros/go-version`

**Release note**:

```improvement user
If a newer version of gardenctl is available, command "gardenctl version" will show notification including where and how to upgrade.
```
