### PR TITLE
refactor namespace to kind of target

### DIFF
--- a/pkg/cmd/ls.go
+++ b/pkg/cmd/ls.go
@@ -30,12 +30,12 @@ import (
 // NewLsCmd returns a new ls command.
 func NewLsCmd(targetReader TargetReader, configReader ConfigReader, ioStreams IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "ls [gardens|projects|seeds|shoots|issues]",
+		Use:          "ls [gardens|projects|seeds|shoots|issues|namespaces]",
 		Short:        "List all resource instances, e.g. list of shoots|issues",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) < 1 || len(args) > 2 {
-				return errors.New("command must be in the format: ls [gardens|projects|seeds|shoots|issues]")
+				return errors.New("command must be in the format: ls [gardens|projects|seeds|shoots|issues|namespaces]")
 			}
 
 			target := targetReader.ReadTarget(pathTarget)
@@ -76,13 +76,15 @@ func NewLsCmd(targetReader TargetReader, configReader ConfigReader, ioStreams IO
 				}
 			case "issues":
 				getIssues(ioStreams)
+			case "namespaces":
+				getNamespaces(ioStreams)
 			default:
-				return errors.New("command must be in the format: ls [gardens|projects|seeds|shoots|issues]")
+				return errors.New("command must be in the format: ls [gardens|projects|seeds|shoots|issues|namespaces]")
 			}
 
 			return nil
 		},
-		ValidArgs: []string{"issues", "projects", "gardens", "seeds", "shoots"},
+		ValidArgs: []string{"issues", "projects", "gardens", "seeds", "shoots", "namespaces"},
 	}
 
 	return cmd
@@ -341,4 +343,15 @@ func getSeedsWithShootsForProject(ioStreams IOStreams) {
 		checkError(err)
 		fmt.Fprint(ioStreams.Out, string(j))
 	}
+}
+
+//getNamespaces get all namespaces based on current kubeconfig
+func getNamespaces(ioStreams IOStreams) {
+	currentConfig := getKubeConfigOfCurrentTarget()
+
+	out, err := ExecCmdReturnOutput("bash", "-c", "export KUBECONFIG="+currentConfig+"; kubectl get ns")
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(out))
 }

--- a/pkg/cmd/ls_test.go
+++ b/pkg/cmd/ls_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Ls command", func() {
 				err := command.Execute()
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("command must be in the format: ls [gardens|projects|seeds|shoots|issues]"))
+				Expect(err.Error()).To(Equal("command must be in the format: ls [gardens|projects|seeds|shoots|issues|namespaces]"))
 			})
 		})
 

--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -646,7 +646,8 @@ func getKubeConfigOfCurrentTarget() (pathToKubeconfig string) {
 	ReadTarget(pathTarget, &targetReal)
 
 	if len(targetReal.Target) == 1 && targetReal.Stack()[0].Kind == "namespace" {
-		panic("the target has only namespace, this is invalid, at least one garden needs to be targeted before using namespace")
+		fmt.Println("the target has only namespace, this is invalid, at least one garden needs to be targeted before using namespace")
+		os.Exit(2)
 	} else if len(targetReal.Target) > 1 && len(targetReal.Target) <= 4 {
 		if targetReal.Stack()[len(targetReal.Target)-1].Kind == "namespace" {
 			target.Target = targetReal.Target[:len(targetReal.Target)-1]
@@ -656,7 +657,8 @@ func getKubeConfigOfCurrentTarget() (pathToKubeconfig string) {
 	} else if len(targetReal.Target) == 1 && targetReal.Stack()[0].Kind != "namespace" {
 		target.Target = targetReal.Target
 	} else {
-		panic("length of target.Stack is illegal")
+		fmt.Println("length of target.Stack is illegal")
+		os.Exit(2)
 	}
 
 	gardenName := target.Stack()[0].Name
@@ -848,14 +850,14 @@ func targetNamespace(targetWriter TargetWriter, ns string) error {
 	ReadTarget(pathTarget, &target)
 
 	if len(target.Target) > 4 {
-		panic("the length is greater than 4 and illegal")
+		return errors.New("the length is greater than 4 and illegal")
 	}
 	if len(target.Target) == 0 {
-		panic("the length is 0 and illegal. at least one garden needs to be targeted")
+		return errors.New("the length is 0 and illegal. at least one garden needs to be targeted")
 	}
 	if len(target.Target) == 1 {
 		if string(target.Target[0].Kind) != "garden" {
-			panic("if one element in target, this needs to be garden")
+			return errors.New("if one element in target, this needs to be garden")
 		}
 		target.Target = append(target.Target, TargetMeta{"namespace", ns})
 	}

--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -542,6 +542,19 @@ func targetShoot(targetWriter TargetWriter, shoot gardencorev1beta1.Shoot) {
 			target.Target = append(target.Target, TargetMeta{"project", projectName})
 			target.Target = append(target.Target, TargetMeta{"shoot", shoot.Name})
 		}
+	} else if len(target.Target) == 4 {
+		drop(targetWriter)
+		drop(targetWriter)
+		drop(targetWriter)
+		if len(target.Target) > 3 && target.Target[1].Kind == "seed" {
+			target.Target = target.Target[:len(target.Target)-3]
+			target.Target = append(target.Target, TargetMeta{"seed", *shoot.Spec.SeedName})
+			target.Target = append(target.Target, TargetMeta{"shoot", shoot.Name})
+		} else if len(target.Target) > 3 && target.Target[1].Kind == "project" {
+			target.Target = target.Target[:len(target.Target)-3]
+			target.Target = append(target.Target, TargetMeta{"project", projectName})
+			target.Target = append(target.Target, TargetMeta{"shoot", shoot.Name})
+		}
 	}
 
 	// Write target

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -79,6 +79,8 @@ const (
 	TargetKindSeed TargetKind = "seed"
 	// TargetKindShoot points to shoot cluster.
 	TargetKindShoot TargetKind = "shoot"
+	// TargetKindNamespace points to namespace.
+	TargetKindNamespace TargetKind = "namespace"
 )
 
 // TargetMeta contains kind and name of target.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes namespace to be one kind of target, just like garden/seed/project/shoot

**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/gardenctl/issues/169

**Special notes for your reviewer**:
* `gardenctl ls namespace` is supported
* i've tested in following scenario/combination
```
gardenctl target -g canary-virtual -s gcp-eu2 -p everest -t ev-1373-b -n kube-system
gardenctl target -g canary-virtual -s gcp-eu2 -p everest -n kube-system
gardenctl target -g canary-virtual -s gcp-eu2 -n kube-system
gardenctl target -g canary-virtual -n kube-system
gardenctl target -s gcp-eu2 -p everest -t ev-1373-b -n kube-system
gardenctl target -s gcp-eu2 -t ev-1373-b -n kube-system
gardenctl target -s gcp-eu2 -n kube-system
gardenctl target -p everest -t ev-1373-b -n kube-system
gardenctl target -p everest -n kube-system
gardenctl target -n kube-system

gardenctl target -g canary-virtual -p everest -t ev-1373-b -n kube-system
gardenctl target -g canary-virtual -p everest -n kube-system
gardenctl target -g canary-virtual -t ev-1373-b -n kube-system

gardenctl target -t ev-1373-b -n kube-system
gardenctl target -p everest -n kube-system
gardenctl target -s gcp-eu2 -n kube-system

gardenctl target namespace kube-system
```

and verified target status in 
`cat /Users/i352986/.garden/sessions/plantingSession/target`
**Release note**:

```improvement operator
Namespace is now supported as one kind of target
gardenctl drop namespace is now supported
gardenctl ls namespaces is now supported
```
