### PR TITLE
Move check for newer version to dedicated command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.3.1
 	github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e
+	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 // indirect
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 h1:YocNLcTBdEdvY3iDK6jfWXvEaM5OCKkjxPKoJRdB3Gg=
+github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2/go.mod h1:76rfSfYPWj01Z85hUf/ituArm797mNKcvINh1OlsZKo=
 github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -147,7 +147,7 @@ func init() {
 	RootCmd.AddCommand(NewKubectlCmd(), NewKaCmd(), NewKsCmd(), NewKgCmd(), NewKnCmd())
 	RootCmd.AddCommand(NewAliyunCmd(targetReader), NewAwsCmd(targetReader), NewAzCmd(targetReader), NewGcloudCmd(targetReader), NewOpenstackCmd(targetReader))
 	RootCmd.AddCommand(NewInfoCmd(targetReader, ioStreams))
-	RootCmd.AddCommand(NewVersionCmd())
+	RootCmd.AddCommand(NewVersionCmd(), NewUpdateCheckCmd())
 
 	RootCmd.SuggestionsMinimumDistance = suggestionsMinimumDistance
 	RootCmd.BashCompletionFunction = bashCompletionFunc

--- a/pkg/cmd/update-check.go
+++ b/pkg/cmd/update-check.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/Masterminds/semver"
+	"github.com/spf13/cobra"
+)
+
+// NewUpdateCheckCmd checks whether a newer version of gardenctl is available
+func NewUpdateCheckCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update-check",
+		Short: "Check whether new gardenctl version is available",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			isAvailable, latestVersion, err := newVersionAvailable(version)
+			if err != nil {
+				return err
+			}
+			if isAvailable {
+				fmt.Printf("New version %q of Gardenctl is available at https://github.com/gardener/gardenctl/releases/latest \n", *latestVersion)
+				fmt.Println("Please get latest version from above URL and see https://github.com/gardener/gardenctl#installation for how to upgrade")
+			} else {
+				fmt.Println("You are using the latest available version")
+			}
+
+			return nil
+		},
+	}
+}
+
+// newVersionAvailable returns whether new version is available.
+func newVersionAvailable(currentVersion string) (bool, *string, error) {
+	gardenctlLatestURL := "https://api.github.com/repos/gardener/gardenctl/releases/latest"
+	resp, err := http.Get(gardenctlLatestURL)
+	if err != nil {
+		return false, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return false, nil, err
+	}
+
+	data := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(body), &data); err != nil {
+		return false, nil, err
+	}
+	var latestVersion string
+	if data["tag_name"] != nil {
+		latestVersion = data["tag_name"].(string)
+	}
+
+	c, err := semver.NewConstraint("> " + currentVersion)
+	if err != nil {
+		return false, nil, err
+	}
+
+	latest, err := semver.NewVersion(latestVersion)
+	if err != nil {
+		return false, nil, err
+	}
+
+	return c.Check(latest), &latestVersion, nil
+}

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -15,13 +15,9 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"runtime"
 
-	"github.com/Masterminds/semver"
 	"github.com/spf13/cobra"
 )
 
@@ -43,51 +39,7 @@ func NewVersionCmd() *cobra.Command {
 		platform    : %s/%s
 `, version, buildDate, runtime.Version(), runtime.Compiler, runtime.GOOS, runtime.GOARCH)
 
-			isAvailable, err := newVersionAvailable(version)
-			if err != nil {
-				return err
-			}
-			if isAvailable {
-				fmt.Println("New version of Gardenctl is available at https://github.com/gardener/gardenctl/releases/latest")
-				fmt.Println("Please get latest version from above URL and see https://github.com/gardener/gardenctl#installation for how to upgrade")
-			}
-
 			return nil
 		},
 	}
-}
-
-// newVersionAvailable returns whether new version is available.
-func newVersionAvailable(currentVersion string) (bool, error) {
-	gardenctlLatestURL := "https://api.github.com/repos/gardener/gardenctl/releases/latest"
-	resp, err := http.Get(gardenctlLatestURL)
-	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return false, err
-	}
-
-	data := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(body), &data); err != nil {
-		return false, err
-	}
-	var latestVersion string
-	if data["tag_name"] != nil {
-		latestVersion = data["tag_name"].(string)
-	}
-
-	c, err := semver.NewConstraint("> " + currentVersion)
-	if err != nil {
-		return false, err
-	}
-
-	latest, err := semver.NewVersion(latestVersion)
-	if err != nil {
-		return false, err
-	}
-
-	return c.Check(latest), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Move check for newer version to dedicated command

It is very annoying `gardenctl version` to depend on network connectivity, thus moving the this check to dedicated command.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The check for newer version is now moved to dedicated sub-command, e.g. `gardenctl update-check`.
```
