### PR TITLE
add support for gardenctl target server / gardenctl target -r

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -136,7 +136,7 @@ func init() {
 	// Commands
 	RootCmd.AddCommand(
 		NewLsCmd(targetReader, configReader, ioStreams),
-		NewTargetCmd(targetReader, targetWriter, configReader, ioStreams),
+		NewTargetCmd(targetReader, targetWriter, configReader, ioStreams, kubeconfigReader),
 		NewDropCmd(targetReader, targetWriter, ioStreams),
 		NewGetCmd(targetReader, configReader, kubeconfigReader, kubeconfigWriter, ioStreams))
 	RootCmd.AddCommand(NewDownloadCmd(), NewShowCmd(), NewLogsCmd())


### PR DESCRIPTION
**What this PR does / why we need it**:
add support for gardenctl target server / gardenctl target -r
the server should be in format "https://servername:443" or "https://ipaddress:443"
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/164
**Special notes for your reviewer**:
`gardenctl target server https://hostname:443`
`gardenctl target -r https://ipaddress:443 -s xxx -n xxx`
**Release note**:

```improvement operator
Added support for `gardenctl target server <uri>` / `gardenctl target -r <uri>` / `gardenctl target --server <uri>` to target a garden without knowing the garden name which can be different on each local installation
- The uri may be an ip or hostname
```
