### PR TITLE
[target server] Fix home directory issue

### DIFF
--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -775,6 +775,9 @@ func serverWrapper(reader ConfigReader, serverName string, kubeconfigReader Kube
 
 	for _, garden := range config.GardenClusters {
 		kc := garden.KubeConfig
+		if strings.Contains(kc, "~") {
+			kc = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(kc, "~", "", 1)))
+		}
 		if _, err := os.Stat(kc); os.IsNotExist(err) {
 			continue
 		}
@@ -890,9 +893,6 @@ func isValidURI(input string) bool {
 }
 
 func getServerValueFromKubeconfig(kubeconfigPath string, kubeconfigReader KubeconfigReader) string {
-	if strings.Contains(kubeconfigPath, "~") {
-		kubeconfigPath = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(kubeconfigPath, "~", "", 1)))
-	}
 	kubeconfig, err := kubeconfigReader.ReadKubeconfig(kubeconfigPath)
 	checkError(err)
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)


### PR DESCRIPTION
**What this PR does / why we need it**:
Patching the `kubeConfig` path in case it contains the `~` (tilde) sign should be done before checking if the file exists, otherwise the check fails

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`target server` now also works when the `kubeConfig` path of the garden configuration contains the `~` (tilde) sign
```
