### PR TITLE
issue-181 refactor kubeconfig path read function

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	yaml2 "github.com/ghodss/yaml"
@@ -160,9 +159,7 @@ func getGarden(name string, configReader ConfigReader, targetReader TargetReader
 	for index, garden := range config.GardenClusters {
 		if garden.Name == name {
 			pathToKubeconfig := config.GardenClusters[index].KubeConfig
-			if strings.Contains(pathToKubeconfig, "~") {
-				pathToKubeconfig = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(pathToKubeconfig, "~", "", 1)))
-			}
+			pathToKubeconfig = TidyKubeconfigWithHomeDir(pathToKubeconfig)
 			kubeconfig, err := kubeconfigReader.ReadKubeconfig(pathToKubeconfig)
 			if err != nil {
 				return err

--- a/pkg/cmd/miscellaneous.go
+++ b/pkg/cmd/miscellaneous.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -88,11 +87,7 @@ func clientToTarget(target TargetKind) (*k8s.Clientset, error) {
 			if target == TargetKindSeed || target == TargetKindShoot {
 				kubeconfig = flag.String("kubeconfig", getKubeConfigOfCurrentTarget(), "(optional) absolute path to the kubeconfig file")
 			} else {
-				if strings.Contains(getGardenKubeConfig(), "~") {
-					pathToKubeconfig = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(getGardenKubeConfig(), "~", "", 1)))
-				} else {
-					pathToKubeconfig = getGardenKubeConfig()
-				}
+				pathToKubeconfig = TidyKubeconfigWithHomeDir(getGardenKubeConfig())
 				kubeconfig = flag.String("kubeconfig", pathToKubeconfig, "(optional) absolute path to the kubeconfig file")
 			}
 		} else {

--- a/pkg/cmd/register.go
+++ b/pkg/cmd/register.go
@@ -126,9 +126,7 @@ func NewRegisterCmd() *cobra.Command {
 				GetGardenConfig(pathGardenConfig, &gardenConfig)
 				for _, cluster := range gardenConfig.GardenClusters {
 					gardenKubeConfig := cluster.KubeConfig
-					if strings.Contains(gardenKubeConfig, "~") {
-						gardenKubeConfig = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(gardenKubeConfig, "~", "", 1)))
-					}
+					gardenKubeConfig = TidyKubeconfigWithHomeDir(gardenKubeConfig)
 					config, err := clientcmd.BuildConfigFromFlags("", gardenKubeConfig)
 					checkError(err)
 					clientset, err := k8s.NewForConfig(config)

--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -649,11 +649,7 @@ func getKubeConfigOfClusterType(clusterType TargetKind) (pathToKubeconfig string
 	gardenName := target.Stack()[0].Name
 	switch clusterType {
 	case TargetKindGarden:
-		if strings.Contains(getGardenKubeConfig(), "~") {
-			pathToKubeconfig = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(getGardenKubeConfig(), "~", "", 1)))
-		} else {
-			pathToKubeconfig = getGardenKubeConfig()
-		}
+		pathToKubeconfig = TidyKubeconfigWithHomeDir(getGardenKubeConfig())
 	case TargetKindSeed:
 		if target.Target[1].Kind == "seed" {
 			pathToKubeconfig = filepath.Join(pathGardenHome, "cache", gardenName, "seeds", target.Target[1].Name, "kubeconfig.yaml")
@@ -694,11 +690,7 @@ func getKubeConfigOfCurrentTarget() (pathToKubeconfig string) {
 
 	gardenName := target.Stack()[0].Name
 	if len(target.Target) == 1 {
-		if strings.Contains(getGardenKubeConfig(), "~") {
-			pathToKubeconfig = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(getGardenKubeConfig(), "~", "", 1)))
-		} else {
-			pathToKubeconfig = getGardenKubeConfig()
-		}
+		pathToKubeconfig = TidyKubeconfigWithHomeDir(getGardenKubeConfig())
 	} else if (len(target.Target) == 2) && (target.Target[1].Kind != "project") {
 		pathToKubeconfig = filepath.Join(pathGardenHome, "cache", gardenName, "seeds", target.Target[1].Name, "kubeconfig.yaml")
 	} else if (len(target.Target) == 2) && (target.Target[1].Kind == "project") {
@@ -775,9 +767,7 @@ func serverWrapper(reader ConfigReader, serverName string, kubeconfigReader Kube
 
 	for _, garden := range config.GardenClusters {
 		kc := garden.KubeConfig
-		if strings.Contains(kc, "~") {
-			kc = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(kc, "~", "", 1)))
-		}
+		kc = TidyKubeconfigWithHomeDir(kc)
 		if _, err := os.Stat(kc); os.IsNotExist(err) {
 			continue
 		}

--- a/pkg/cmd/unregister.go
+++ b/pkg/cmd/unregister.go
@@ -112,9 +112,7 @@ func NewUnregisterCmd() *cobra.Command {
 				GetGardenConfig(pathGardenConfig, &gardenConfig)
 				for _, cluster := range gardenConfig.GardenClusters {
 					gardenKubeConfig := cluster.KubeConfig
-					if strings.Contains(gardenKubeConfig, "~") {
-						gardenKubeConfig = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(gardenKubeConfig, "~", "", 1)))
-					}
+					gardenKubeConfig = TidyKubeconfigWithHomeDir(gardenKubeConfig)
 					config, err := clientcmd.BuildConfigFromFlags("", gardenKubeConfig)
 					checkError(err)
 					clientset, err := k8s.NewForConfig(config)

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -217,4 +218,12 @@ func FetchShootFromTarget(target TargetInterface) (*gardencorev1beta1.Shoot, err
 	}
 
 	return shoot, nil
+}
+
+//TidyKubeconfigWithHomeDir check if kubeconfig path contains ~, replace ~ with user home dir
+func TidyKubeconfigWithHomeDir(pathToKubeconfig string) string {
+	if strings.Contains(pathToKubeconfig, "~") {
+		pathToKubeconfig = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(pathToKubeconfig, "~", "", 1)))
+	}
+	return pathToKubeconfig
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
in g/gardenctl repo there are many 
```
if strings.Contains(pathToKubeconfig, "~") {
	pathToKubeconfig = filepath.Clean(filepath.Join(HomeDir(), strings.Replace(pathToKubeconfig, "~", "", 1)))
}
```
refactor them to be one function and make code clean
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/181

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
