### PR TITLE
gardenctl logs tf fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ Targets represent a hierarchical structure of resources. On top, there is/are th
 `gardenctl logs etcd-main --elasticsearch`
 - Show last 100 logs from elasticsearch from the last 2 hours  
 `gardenctl logs etcd-main --elasticsearch --since=2h --tail=100`
+- Show logs from seed nodes 
+`gardenctl target -g garden-name -s seed-name`  
+`gardenctl logs tf infra shoot-name`
+- Show logs from shoot nodes  
+`gardenctl target -g garden-name -t shoot-name`  
+`gardenctl logs api | scheduler | controller-manager | etcd-main -c etcd |etcd-main -c backup-restore | vpn-seed | vpn-shoot | machine-controller-manager | prometheus |grafana | alertmanager | cluster-autoscaler`
+- Show logs from garden nodes   
+`gardenctl target -g garden-name`  
+`gardenctl logs gardener-apiserver | gardener-controller-manager`  
 
 ## Advanced usage based on JsonQuery
 

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -68,7 +68,7 @@ func NewLogsCmd() *cobra.Command {
 }
 
 func validateArgs(args []string) {
-	if len(args) < 1 || len(args) > 2 {
+	if len(args) < 1 || len(args) > 3 {
 		fmt.Println("Command must be in the format: logs (gardener-apiserver|gardener-controller-manager|gardener-dashboard|api|scheduler|controller-manager|etcd-operator|etcd-main[etcd backup-restore]|etcd-events[etcd backup-restore]|addon-manager|vpn-seed|vpn-shoot|machine-controller-manager|kubernetes-dashboard|prometheus|grafana|alertmanager|tf (infra|dns|ingress)|cluster-autoscaler flags(--elasticsearch|--tail|--since|--since-time|--timestamps)")
 		os.Exit(2)
 	}
@@ -156,17 +156,22 @@ func runCommand(args []string) {
 	case "cluster-autoscaler":
 		logsClusterAutoscaler()
 	case "tf":
-		if len(args) == 1 {
-			logsTf()
+		if len(args) == 1 || len(args) < 3 {
+			logsTfHelp()
 			break
 		}
+
+		var prefixName string = (args[02])
 		switch args[1] {
 		case "infra":
-			logsInfra()
+			str := prefixName + ".infra.tf"
+			logsInfra(str)
 		case "dns":
-			logsDNS()
+			str := prefixName + ".dns.tf"
+			logsDNS(str)
 		case "ingress":
-			logsIngress()
+			str := prefixName + ".ingress.tf"
+			logsIngress(str)
 		default:
 			fmt.Println("Command must be in the format: logs (gardener-apiserver|gardener-controller-manager|gardener-dashboard|api|scheduler|controller-manager|etcd-operator|etcd-main[etcd backup-restore]|etcd-events[etcd backup-restore]|addon-manager|vpn-seed|vpn-shoot|auto-node-repair|kubernetes-dashboard|prometheus|grafana|alertmanager|tf (infra|dns|ingress)|cluster-autoscaler)")
 		}
@@ -535,23 +540,23 @@ func logsTerraform(toMatch string) {
 }
 
 // logsTf prints the logfiles of tf job
-func logsTf() {
-	logsTerraform("tf-job")
+func logsTfHelp() {
+	fmt.Println("Command must be in the format: logs tf (infra|dns|ingress) shoot name")
 }
 
 // logsInfra prints the logfiles of tf infra job
-func logsInfra() {
-	logsTerraform("infra.tf")
+func logsInfra(str string) {
+	logsTerraform(str)
 }
 
 // logsDNS prints the logfiles of tf dns job
-func logsDNS() {
-	logsTerraform("dns.tf")
+func logsDNS(str string) {
+	logsTerraform(str)
 }
 
 // logsIngress prints the logfiles of tf ingress job
-func logsIngress() {
-	logsTerraform("ingress.tf")
+func logsIngress(str string) {
+	logsTerraform(str)
 }
 
 type logFlags struct {

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -541,17 +541,17 @@ func logsTf() {
 
 // logsInfra prints the logfiles of tf infra job
 func logsInfra() {
-	logsTerraform("infra.tf-job")
+	logsTerraform("infra.tf")
 }
 
 // logsDNS prints the logfiles of tf dns job
 func logsDNS() {
-	logsTerraform("dns.tf-job")
+	logsTerraform("dns.tf")
 }
 
 // logsIngress prints the logfiles of tf ingress job
 func logsIngress() {
-	logsTerraform("ingress.tf-job")
+	logsTerraform("ingress.tf")
 }
 
 type logFlags struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
add: `gardenctl logs` readme 
fix: `gardenctl logs tf infra` result output null 
add: `gardenctl logs tf infra shoot-name` result output display only from shoot cluster instead of all shoot clusters 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/183

**Special notes for your reviewer**:
![image](https://user-images.githubusercontent.com/42234376/78876020-54c83c00-7a81-11ea-886e-4a39e44ae8e9.png)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
gardenctl logs tf infra output null fix and logs function README update
```
