### PR TITLE
add support for target url or target -u with dashboard url

### DIFF
--- a/pkg/cmd/target_test.go
+++ b/pkg/cmd/target_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Target command", func() {
 		},
 		Entry("with missing target kind", targetCase{
 			args:        []string{},
-			expectedErr: "command must be in the format: target <project|garden|seed|shoot|namespace|server> NAME",
+			expectedErr: "command must be in the format: target <project|garden|seed|shoot|namespace|server|dashboardUrl> NAME",
 		}),
 		Entry("with 2 garden cluster names", targetCase{
 			args:        []string{"garden", "prod-1", "prod-2"},

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -133,8 +133,9 @@ type GardenClusters struct {
 
 // GardenClusterMeta contains name and path to kubeconfig of gardencluster
 type GardenClusterMeta struct {
-	Name       string `yaml:"name,omitempty" json:"name,omitempty"`
-	KubeConfig string `yaml:"kubeConfig,omitempty" json:"kubeConfig,omitempty"`
+	Name         string `yaml:"name,omitempty" json:"name,omitempty"`
+	KubeConfig   string `yaml:"kubeConfig,omitempty" json:"kubeConfig,omitempty"`
+	DashboardURL string `yaml:"dashboardUrl,omitempty" json:"dashboardUrl,omitempty"`
 }
 
 // Issues contains all projects with issues


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable `gardenctl target dashboardUrl dashboard_url` or `gardenctl target -u dashboard_url` for directly targeting garden and shoot

This requires your (virtual) garden config to have `dashboardUrl` field set.
E.g.
```yaml
gardenClusters:
  - kubeConfig: /path/to/kubeconfig.yaml
    name: foo
    dashboardUrl: https://dashboard.foo.example.com
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/188

**Special notes for your reviewer**:
the url could be in following two formats:
- https://<url-to-dashboard>/namespace/garden-project/shoots/my-shoot/
- https://<url-to-dashboard>/namespace/garden-project/shoots/my-shoot

**Release note**:
```improvement operator
Enable `gardenctl target dashboardUrl <dashboard_url>` or `gardenctl target -u <dashboard_url>` for directly targeting garden and shoot. Make sure to have `dashboardUrl` field set for each of your (virtual) garden configurations
```
