### PR TITLE
add shoot target check when target.Stack() length >= 3

### DIFF
--- a/pkg/cmd/aliyun.go
+++ b/pkg/cmd/aliyun.go
@@ -28,7 +28,7 @@ func NewAliyunCmd(targetReader TargetReader) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := targetReader.ReadTarget(pathTarget)
-			if len(target.Stack()) < 3 {
+			if !CheckShootIsTargeted(target) {
 				return errors.New("no shoot targeted")
 			}
 

--- a/pkg/cmd/aws.go
+++ b/pkg/cmd/aws.go
@@ -28,7 +28,7 @@ func NewAwsCmd(targetReader TargetReader) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := targetReader.ReadTarget(pathTarget)
-			if len(target.Stack()) < 3 {
+			if !CheckShootIsTargeted(target) {
 				return errors.New("no shoot targeted")
 			}
 

--- a/pkg/cmd/az.go
+++ b/pkg/cmd/az.go
@@ -28,7 +28,7 @@ func NewAzCmd(targetReader TargetReader) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := targetReader.ReadTarget(pathTarget)
-			if len(target.Stack()) < 3 {
+			if !CheckShootIsTargeted(target) {
 				return errors.New("no shoot targeted")
 			}
 

--- a/pkg/cmd/gcloud.go
+++ b/pkg/cmd/gcloud.go
@@ -28,7 +28,7 @@ func NewGcloudCmd(targetReader TargetReader) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := targetReader.ReadTarget(pathTarget)
-			if len(target.Stack()) < 3 {
+			if !CheckShootIsTargeted(target) {
 				return errors.New("no shoot targeted")
 			}
 

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -236,7 +236,7 @@ func getSeed(name string, targetReader TargetReader, ioStreams IOStreams) error 
 func getShoot(name string, targetReader TargetReader, kubeconfigWriter KubeconfigWriter, ioStreams IOStreams) error {
 	target := targetReader.ReadTarget(pathTarget)
 	if name == "" {
-		if len(target.Stack()) < 3 {
+		if !CheckShootIsTargeted(target) {
 			return errors.New("no shoot targeted")
 		}
 	} else if name != "" {

--- a/pkg/cmd/openstack.go
+++ b/pkg/cmd/openstack.go
@@ -28,7 +28,7 @@ func NewOpenstackCmd(targetReader TargetReader) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := targetReader.ReadTarget(pathTarget)
-			if len(target.Stack()) < 3 {
+			if !CheckShootIsTargeted(target) {
 				return errors.New("no shoot targeted")
 			}
 

--- a/pkg/cmd/ssh.go
+++ b/pkg/cmd/ssh.go
@@ -44,7 +44,7 @@ func NewSSHCmd(reader TargetReader, ioStreams IOStreams) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := reader.ReadTarget(pathTarget)
-			if len(target.Stack()) < 3 {
+			if !CheckShootIsTargeted(target) {
 				return errors.New("no shoot targeted")
 			}
 

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -227,3 +227,11 @@ func TidyKubeconfigWithHomeDir(pathToKubeconfig string) string {
 	}
 	return pathToKubeconfig
 }
+
+//CheckShootIsTargeted check if current target has shoot targeted
+func CheckShootIsTargeted(target TargetInterface) bool {
+	if (len(target.Stack()) < 3) || (target.Stack()[len(target.Stack())-1].Kind == "namespace" && target.Stack()[len(target.Stack())-2].Kind != "shoot") {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes ago we only have `garden` / `seed` / `project` / `shoot` in kinds of target, so when len(target.Stack())>=3, there must be one shoot targeted.
Now there's one new kind of `namespace` in kinds of target, so when len(target.Stack())>=3 , shoot might not be targeted, which might causing some command fail (e.g. `gardenctl az` related commands)

**Which issue(s) this PR fixes**:

Fixes https://github.com/gardener/gardenctl/issues/196

**Special notes for your reviewer**:

This error was found in executing `gardenctl az` but also found across the whole project, so refactor them all together

**Release note**:
```improvement user
Fixes gardenctl related error in certain kind of scenario when gardenctl not targeting shoot
```
