### PR TITLE
fix alicloud ssh

### DIFF
--- a/pkg/cmd/ssh.go
+++ b/pkg/cmd/ssh.go
@@ -93,7 +93,7 @@ func NewSSHCmd(reader TargetReader, ioStreams IOStreams) *cobra.Command {
 			case "azure":
 				sshToAZNode(args[0], path, user, pathSSKeypair, sshPublicKey)
 			case "alicloud":
-				sshToAlicloudNode(args[0], path, user, sshPublicKey)
+				sshToAlicloudNode(args[0], path, user, pathSSKeypair, sshPublicKey)
 			case "openstack":
 			default:
 				return fmt.Errorf("infrastructure type %q not found", infraType)


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously gardenctl fixed the problem that when doing ssh, an id_rsa.pub key will be created in current folder. However, it was not applied to alicloud provider.
This PR fixes alicloud ssh command and makes it aligned with other providers'.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix the issue that breaks ssh command for provider alicloud.
```
