### PR TITLE
Add github action to update gardenctl homebrew-tap

### DIFF
--- a/.github/workflows/update-gardenctl.yml
+++ b/.github/workflows/update-gardenctl.yml
@@ -1,0 +1,17 @@
+name: gardenctl-updater
+
+on:
+  release:
+    types:
+      - published
+jobs:
+  update-hombrew-tap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send update with latest versions to gardener/homebrew-tap
+        run: |
+          echo '{"event_type": "update", "client_payload": { "tag": "'"$GITHUB_REF"'", "sha": "'"$GITHUB_SHA"'"}}'
+          curl -X POST https://api.github.com/repos/gardener/homebrew-tap/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.ACCESS_TOKEN }} \
+          --data '{"event_type": "update", "client_payload": { "tag": "'"$GITHUB_REF"'", "sha": "'"$GITHUB_SHA"'"}}'


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a github action to update gardenctl  homebrew-tap


**Note to reviewer** 
We should create a secret token able to do workflow updates

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An update to homebrew-tap is now automatically triggered. 
```
