### PR TITLE
Remove jq tool dependency

### DIFF
--- a/pkg/cmd/miscellaneous.go
+++ b/pkg/cmd/miscellaneous.go
@@ -255,13 +255,21 @@ func getEmail(githubURL string) string {
 	if githubURL == "" {
 		return "null"
 	}
-	res, err := ExecCmdReturnOutput("bash", "-c", "curl -ks "+githubURL+"/api/v3/users/"+os.Getenv("USER")+" | jq -r .email")
+	res, err := ExecCmdReturnOutput("bash", "-c", "curl -ks "+githubURL+"/api/v3/users/"+os.Getenv("USER"))
+	checkError(err)
+
 	if err != nil {
 		fmt.Println("Cmd was unsuccessful")
 		os.Exit(2)
 	}
-	fmt.Printf("used GitHub email: %s\n", res)
-	return res
+
+	var yamlOut map[string]interface{}
+	err = yaml.Unmarshal([]byte(res), &yamlOut)
+	checkError(err)
+
+	githubEmail := yamlOut["email"].(string)
+	fmt.Printf("used GitHub email: %s\n", githubEmail)
+	return githubEmail
 }
 
 func getEmailFromConfig() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
gardenctl should work when jq is not installed
**Which issue(s) this PR fixes**:
Fixes #74 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Remove jq tool dependency
```
