### PR TITLE
validate shoot project matches shoot namespace

### DIFF
--- a/pkg/cmd/operate.go
+++ b/pkg/cmd/operate.go
@@ -62,7 +62,7 @@ func operate(provider, arguments string) {
 	shootList, err := gardenClientset.CoreV1beta1().Shoots("").List(metav1.ListOptions{})
 	checkError(err)
 	for _, shoot := range shootList.Items {
-		if shoot.Name == target.Target[2].Name {
+		if shoot.Name == target.Target[2].Name && strings.HasSuffix(shoot.Namespace, target.Target[1].Name) {
 			secretBindingName := shoot.Spec.SecretBindingName
 			region = shoot.Spec.Region
 			namespaceSecretBinding := shoot.Namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
gardenctl gets wrong shoot creds for shoots w/ same name across diff projects
**Which issue(s) this PR fixes**:
Fixes #147 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
validate shoot project matches shoot namespace w/ same name across diff projects
```
