### PR TITLE
Add kubectx support for gardenctl

### DIFF
--- a/pkg/cmd/kubectx.go
+++ b/pkg/cmd/kubectx.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// NewKubectxCmd returns a new kubectx command.
+func NewKubectxCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "kubectx <args>",
+		Aliases: []string{"kx"},
+		Short:   "",
+		Run: func(cmd *cobra.Command, args []string) {
+			arguments := "kubectx " + strings.Join(args[:], " ")
+			kubectx(arguments)
+		},
+	}
+}
+
+// kubectx executes a kubectx command on targeted cluster
+func kubectx(args string) {
+	KUBECONFIG = getKubeConfigOfCurrentTarget()
+	_, err := exec.LookPath("kubectx")
+	if err != nil {
+		fmt.Println("Kubectx is not installed on your system")
+		fmt.Println("Please go to https://github.com/ahmetb/kubectx for how to install it")
+		os.Exit(2)
+	}
+	err = ExecCmd(nil, args, false, "KUBECONFIG="+KUBECONFIG)
+	checkError(err)
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -145,6 +145,7 @@ func init() {
 	RootCmd.AddCommand(NewShellCmd(targetReader, ioStreams))
 	RootCmd.AddCommand(NewSSHCmd(targetReader, ioStreams))
 	RootCmd.AddCommand(NewKubectlCmd(), NewKaCmd(), NewKsCmd(), NewKgCmd(), NewKnCmd())
+	RootCmd.AddCommand(NewKubectxCmd())
 	RootCmd.AddCommand(NewAliyunCmd(targetReader), NewAwsCmd(targetReader), NewAzCmd(targetReader), NewGcloudCmd(targetReader), NewOpenstackCmd(targetReader))
 	RootCmd.AddCommand(NewInfoCmd(targetReader, ioStreams))
 	RootCmd.AddCommand(NewVersionCmd(), NewUpdateCheckCmd())


### PR DESCRIPTION
**What this PR does / why we need it**:
Add kubectx support for gardenctl

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/211

**Special notes for your reviewer**:

**Release note**:

```improvement operator
add kubectx support for gardenctl
```
