### PR TITLE
Add pipeline job for automatic creation and publish of gardenctl docker image

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -41,3 +41,7 @@ gardenctl:
             internal_scp_workspace:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
+        publish:
+          dockerimages:
+            gardenctl:
+              tag_as_latest: true

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -4,6 +4,8 @@ gardenctl:
     repo: ~
     traits:
       version:
+        preprocess:
+          'inject-commit-hash'
         inject_effective_version: true
       publish:
         dockerimages:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,6 +5,14 @@ gardenctl:
     traits:
       version:
         inject_effective_version: true
+      publish:
+        dockerimages:
+          gardenctl:
+            image: 'eu.gcr.io/gardener-project/gardener/gardenctl'
+            registry: 'gcr-readwrite'
+            inputs:
+              repos:
+                source: ~
     steps:
       check:
         image: 'golang:1.13'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the pipeline definition with automatic publishing of a docker image based on the already created dockerfile.


**Which issue(s) this PR fixes**:
Fixes #210 

**Special notes for your reviewer**:
@petersutter 
As discussed in #210 I oriented on the supplied examples in the issue. Let me know in case I should go for any changes👍 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```

Best Regards & Take Care
Robert
