### PR TITLE
Remove AWS instance profile from bastion nodes

### DIFF
--- a/pkg/cmd/ssh_aws.go
+++ b/pkg/cmd/ssh_aws.go
@@ -253,7 +253,7 @@ func (a *AwsInstanceAttribute) createBastionHostInstance() {
 	}
 
 	// create bastion host
-	arguments = "aws " + fmt.Sprintf("ec2 run-instances --iam-instance-profile Name=%s --image-id %s --count 1 --instance-type %s --key-name %s --security-group-ids %s --subnet-id %s --associate-public-ip-address --user-data file://%s --tag-specifications ResourceType=instance,Tags=[{Key=Name,Value=%s},{Key=component,Value=gardenctl}] ResourceType=volume,Tags=[{Key=component,Value=gardenctl}]", a.BastionInstanceName, a.ImageID, instanceType, a.KeyName, a.BastionSecurityGroupID, a.SubnetID, tmpfile.Name(), a.BastionInstanceName)
+	arguments = "aws " + fmt.Sprintf("ec2 run-instances --image-id %s --count 1 --instance-type %s --key-name %s --security-group-ids %s --subnet-id %s --associate-public-ip-address --user-data file://%s --tag-specifications ResourceType=instance,Tags=[{Key=Name,Value=%s},{Key=component,Value=gardenctl}] ResourceType=volume,Tags=[{Key=component,Value=gardenctl}]", a.ImageID, instanceType, a.KeyName, a.BastionSecurityGroupID, a.SubnetID, tmpfile.Name(), a.BastionInstanceName)
 	captured = capture()
 	operate("aws", arguments)
 	capturedOutput, err = captured()


### PR DESCRIPTION
**What this PR does / why we need it**:

AWS IAM Instance Profiles are not needed for bastions as they should be used only to jump to the broken instances.
See AWS [EC2 RunInstances API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html).

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:

Related issue https://github.com/gardener/gardener-extension-provider-aws/issues/4

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
AWS Bastion nodes no longer have any instance profiles associated with them.
```
