### PR TITLE
remove exec and auth provider check to utilize kubeconfig with oidc enabled

### DIFF
--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -164,7 +164,7 @@ func NewConfigFromBytes(kubeconfig string) *restclient.Config {
 // ValidateClientConfig validates that the auth info of a given kubeconfig doesn't have unsupported fields.
 func ValidateClientConfig(config clientcmdapi.Config) error {
 	validFields := []string{"client-certificate-data", "client-key-data", "token", "username", "password"}
-
+	pathOfKubeconfig := getKubeConfigOfCurrentTarget()
 	for user, authInfo := range config.AuthInfos {
 		switch {
 		case authInfo.ClientCertificate != "":
@@ -175,10 +175,14 @@ func ValidateClientConfig(config clientcmdapi.Config) error {
 			return fmt.Errorf("token files are not supported (user %q), these are the valid fields: %+v", user, validFields)
 		case authInfo.Impersonate != "" || len(authInfo.ImpersonateGroups) > 0:
 			return fmt.Errorf("impersonation is not supported, these are the valid fields: %+v", validFields)
-		// case authInfo.AuthProvider != nil && len(authInfo.AuthProvider.Config) > 0:
-		// 	return fmt.Errorf("auth provider configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
-		// case authInfo.Exec != nil:
-		// 	return fmt.Errorf("exec configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
+		case authInfo.AuthProvider != nil && len(authInfo.AuthProvider.Config) > 0:
+			fmt.Printf("Kubeconfig under path %s contains auth provider configurations that could contain malicious code. Please only continue if you have verified it to be uncritical\n", pathOfKubeconfig)
+			return nil
+			// 	return fmt.Errorf("auth provider configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
+		case authInfo.Exec != nil:
+			fmt.Printf("Kubeconfig under path %s contains exec configurations that could contain malicious code. Please only continue if you have verified it to be uncritical\n", pathOfKubeconfig)
+			return nil
+			// 	return fmt.Errorf("exec configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
 		}
 	}
 

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -175,10 +175,10 @@ func ValidateClientConfig(config clientcmdapi.Config) error {
 			return fmt.Errorf("token files are not supported (user %q), these are the valid fields: %+v", user, validFields)
 		case authInfo.Impersonate != "" || len(authInfo.ImpersonateGroups) > 0:
 			return fmt.Errorf("impersonation is not supported, these are the valid fields: %+v", validFields)
-		case authInfo.AuthProvider != nil && len(authInfo.AuthProvider.Config) > 0:
-			return fmt.Errorf("auth provider configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
-		case authInfo.Exec != nil:
-			return fmt.Errorf("exec configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
+		// case authInfo.AuthProvider != nil && len(authInfo.AuthProvider.Config) > 0:
+		// 	return fmt.Errorf("auth provider configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
+		// case authInfo.Exec != nil:
+		// 	return fmt.Errorf("exec configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In gardenctl there's validation against kubeconfig which doesn't allow kubeconfig contains `exec` or `auth provider` to prevent malicious executable code. Now with OIDC enabled, kubeconfig contains exec part, so i would like to propose this PR to discuss whether we can remove this check in gardenctl 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/217 and https://github.com/gardener/gardenctl/issues/175

**Special notes for your reviewer**:

/CC @dansible @ThormaehlenFred @DockToFuture @ialidzhikov @vpnachev @donistz 

Basically this PR enables gardenctl to utilize oidc enabled kubeconfig, i did some basic testing like `gardenctl target garden/seed/shoot` and then do some kubectl operation like `gardenctl k get pods -- -n kube-system` etc , so far so good.

Indeed it is security to allow using kubeconfig with exec part which can execute any code, as discussed in https://banzaicloud.com/blog/kubeconfig-security/ (thanks for @DockToFuture ), we could discuss e.g. we add some warning message in gardenctl project regarding this? to let people know gardenctl allow using kubeconfig contains exec part which could be security risk....

**Release note**:

```improvement operator
remove kubeconfig validation for exec and auth provider, to utilize kubeconfig with oidc enabled.
```
