### PR TITLE
restrict Public IP when use ssh access cloud

### DIFF
--- a/pkg/cmd/miscellaneous.go
+++ b/pkg/cmd/miscellaneous.go
@@ -323,3 +323,9 @@ func isIP(word string) bool {
 	}
 	return true
 }
+
+func getPublicIP() string {
+	result, err := ExecCmdReturnOutput("bash", "-c", "curl ifconfig.me")
+	checkError(err)
+	return result
+}

--- a/pkg/cmd/ssh.go
+++ b/pkg/cmd/ssh.go
@@ -83,6 +83,7 @@ func NewSSHCmd(reader TargetReader, ioStreams IOStreams) *cobra.Command {
 			checkError(err)
 			fmt.Println("Downloaded id_rsa key")
 
+			fmt.Println("Check Public IP")
 			myPublicIP := getPublicIP()
 
 			sshPublicKey := sshKeypairSecret.Data["id_rsa.pub"]

--- a/pkg/cmd/ssh.go
+++ b/pkg/cmd/ssh.go
@@ -83,17 +83,19 @@ func NewSSHCmd(reader TargetReader, ioStreams IOStreams) *cobra.Command {
 			checkError(err)
 			fmt.Println("Downloaded id_rsa key")
 
+			myPublicIP := getPublicIP()
+
 			sshPublicKey := sshKeypairSecret.Data["id_rsa.pub"]
 			infraType := shoot.Spec.Provider.Type
 			switch infraType {
 			case "aws":
-				sshToAWSNode(args[0], path, user, pathSSKeypair, sshPublicKey)
+				sshToAWSNode(args[0], path, user, pathSSKeypair, sshPublicKey, myPublicIP)
 			case "gcp":
-				sshToGCPNode(args[0], path, user, pathSSKeypair, sshPublicKey)
+				sshToGCPNode(args[0], path, user, pathSSKeypair, sshPublicKey, myPublicIP)
 			case "azure":
-				sshToAZNode(args[0], path, user, pathSSKeypair, sshPublicKey)
+				sshToAZNode(args[0], path, user, pathSSKeypair, sshPublicKey, myPublicIP)
 			case "alicloud":
-				sshToAlicloudNode(args[0], path, user, pathSSKeypair, sshPublicKey)
+				sshToAlicloudNode(args[0], path, user, pathSSKeypair, sshPublicKey, myPublicIP)
 			case "openstack":
 			default:
 				return fmt.Errorf("infrastructure type %q not found", infraType)

--- a/pkg/cmd/ssh_alicloud.go
+++ b/pkg/cmd/ssh_alicloud.go
@@ -51,6 +51,7 @@ type AliyunInstanceAttribute struct {
 	PrivateIP                string
 	BastionIP                string
 	BastionSSHUser           string
+	MyPublicIP               string
 }
 
 // AliyunInstanceTypeSpec stores all the critical information for choosing a instance type on Alicloud.
@@ -68,7 +69,7 @@ type AliyunInstanceTypeSpec struct {
 }
 
 // sshToAlicloudNode provides cmds to ssh to alicloud via a public ip and clean it up afterwards.
-func sshToAlicloudNode(nodeName, path, user, pathSSKeypair string, sshPublicKey []byte) {
+func sshToAlicloudNode(nodeName, path, user, pathSSKeypair string, sshPublicKey []byte, myPublicIP string) {
 	// Check if this is a cleanup command
 	if nodeName == "cleanup" {
 		cleanupAliyunBastionHost()
@@ -82,7 +83,7 @@ func sshToAlicloudNode(nodeName, path, user, pathSSKeypair string, sshPublicKey 
 	fmt.Println("Aliyun cli configured.")
 
 	a := &AliyunInstanceAttribute{}
-
+	a.MyPublicIP = myPublicIP + "/32"
 	fmt.Println("")
 	fmt.Println("(2/5) Fetching data from target shoot cluster")
 	a.fetchAttributes(nodeName)
@@ -198,9 +199,7 @@ func (a *AliyunInstanceAttribute) createBastionHostSecurityGroup() {
 			os.Exit(2)
 		}
 		fmt.Println("Configuring bastion host security group rules...")
-		_, err = ExecCmdReturnOutput("bash", "-c", "aliyun ecs AuthorizeSecurityGroup --Policy Accept --NicType intranet --Priority 1 --SourceCidrIp 0.0.0.0/0 --PortRange 22/22 --IpProtocol udp --SecurityGroupId="+a.BastionSecurityGroupID)
-		checkError(err)
-		_, err = ExecCmdReturnOutput("bash", "-c", "aliyun ecs AuthorizeSecurityGroup --Policy Accept --NicType intranet --Priority 1 --SourceCidrIp 0.0.0.0/0 --PortRange 22/22 --IpProtocol tcp --SecurityGroupId="+a.BastionSecurityGroupID)
+		_, err = ExecCmdReturnOutput("bash", "-c", "aliyun ecs AuthorizeSecurityGroup --Policy Accept --NicType intranet --Priority 1 --SourceCidrIp %s --PortRange 22/22 --IpProtocol tcp --SecurityGroupId="+a.BastionSecurityGroupID, a.MyPublicIP)
 		checkError(err)
 		time.Sleep(time.Second * 10)
 		fmt.Println("Bastion host security group rules configured.")

--- a/pkg/cmd/ssh_aws.go
+++ b/pkg/cmd/ssh_aws.go
@@ -48,12 +48,14 @@ type AwsInstanceAttribute struct {
 	BastionSecurityGroupName string
 	UserData                 []byte
 	SSHPublicKey             []byte
+	MyPublicIP               string
 }
 
 // sshToAWSNode provides cmds to ssh to aws via a bastions host and clean it up afterwards
-func sshToAWSNode(nodeName, path, user, pathSSKeypair string, sshPublicKey []byte) {
+func sshToAWSNode(nodeName, path, user, pathSSKeypair string, sshPublicKey []byte, myPublicIP string) {
 	a := &AwsInstanceAttribute{}
 	a.SSHPublicKey = sshPublicKey
+	a.MyPublicIP = myPublicIP + "/32"
 	fmt.Println("")
 
 	fmt.Println("(1/4) Fetching data from target shoot cluster")
@@ -172,7 +174,7 @@ func (a *AwsInstanceAttribute) createBastionHostSecurityGroup() {
 	a.BastionSecurityGroupID = strings.Trim((capturedOutput), "\n")
 	arguments = fmt.Sprintf("aws ec2 create-tags --resources %s  --tags Key=component,Value=gardenctl", a.BastionSecurityGroupID)
 	operate("aws", arguments)
-	arguments = fmt.Sprintf("aws ec2 authorize-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr 0.0.0.0/0", a.BastionSecurityGroupID)
+	arguments = fmt.Sprintf("aws ec2 authorize-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr %s", a.BastionSecurityGroupID, a.MyPublicIP)
 	operate("aws", arguments)
 	fmt.Println("Bastion host security group set up.")
 


### PR DESCRIPTION
What this PR does / why we need it:
fetch user Public IP and restrict the source IP range
create ssh rules in security group base on user public IP when use gardenctl ssh instead of 0.0.0.0/0

Which issue(s) this PR fixes:
Fixes #222

Special notes for your reviewer:

Release note:
restrict the source IP range when use gardenctl ssh


the previous PR closed by the accident 