### PR TITLE
add documentation for how to enable source completion in zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,18 @@ sudo mv bin/darwin-amd64/gardenctl-darwin-amd64 /usr/local/bin/gardenctl
 
 `gardenctl` supports auto completion. This recommended feature is bound to `gardenctl` or the alias `g`. To configure it you can run:
 
+if you are using `bash`:
+
 ```bash
 echo "source <(gardenctl completion bash)" >> ~/.bashrc
 source ~/.bashrc
+```
+
+if you are using `zsh`:
+
+```bash
+echo "source <(gardenctl completion zsh)" >> ~/.zshrc
+source ~/.zshrc
 ```
 
 ### Via Dockerfile


### PR DESCRIPTION
**What this PR does / why we need it**:
in README.md, there's only guide for how to enable command line auto completion of `bash`, actually different command should be run to enable auto completion when you are running `bash` or `zsh`
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/227

**Special notes for your reviewer**:

**Release note**:

```improvement operator
add documentation for how to enable cli auto completion in zsh
```
