### PR TITLE
use gardenctl-maintainers group

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # gardenctl maintainers
-*   @DockToFuture @ialidzhikov
+*   @gardener/gardenctl-maintainers


### PR DESCRIPTION
**What this PR does / why we need it**:

Use gardenctl-maintainers group for CODEOWNERS
