### PR TITLE
pass cloud cli creds as args only

### DIFF
--- a/pkg/cmd/operate.go
+++ b/pkg/cmd/operate.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	openstackinstall "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
@@ -31,21 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
-
-// removeOldEntry removes old credential and config entry for gardenctl if existing
-func removeOldEntry(filePath, contains string) {
-	input, err := ioutil.ReadFile(filePath)
-	checkError(err)
-	lines := strings.Split(string(input), "\n")
-	for i, line := range lines {
-		if strings.Contains(line, contains) {
-			lines = append(lines[:i], lines[i+3:]...)
-		}
-	}
-	output := strings.Join(lines, "\n")
-	err = ioutil.WriteFile(filePath, []byte(output), 0644)
-	checkError(err)
-}
 
 // operate executes a command on specified cli with pulled credentials for target
 func operate(provider, arguments string) {
@@ -76,43 +60,10 @@ func operate(provider, arguments string) {
 	secret, err := Client.CoreV1().Secrets(namespaceSecret).Get((secretName), metav1.GetOptions{})
 	checkError(err)
 
-	gardenName := target.Stack()[0].Name
-	projectsPath := filepath.Join("cache", gardenName, "projects", target.Target[1].Name, target.Target[2].Name)
-	seedsPath := filepath.Join("cache", gardenName, "seeds", target.Target[1].Name, target.Target[2].Name)
-
 	switch provider {
 	case "aws":
 		accessKeyID := []byte(secret.Data["accessKeyID"])
 		secretAccessKey := []byte(secret.Data["secretAccessKey"])
-		if !cachevar {
-			awsPathCredentials := ""
-			awsPathConfig := ""
-			if target.Target[1].Kind == "project" {
-				CreateDir(filepath.Join(pathGardenHome, projectsPath, ".aws"), 0751)
-				awsPathCredentials = filepath.Join(projectsPath, ".aws", "credentials")
-				awsPathConfig = filepath.Join(projectsPath, ".aws", "config")
-			} else if target.Target[1].Kind == "seed" {
-				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".aws"), 0751)
-				awsPathCredentials = filepath.Join(seedsPath, ".aws", "credentials")
-				awsPathConfig = filepath.Join(seedsPath, ".aws", "config")
-			}
-			CreateFileIfNotExists(filepath.Join(pathGardenHome, awsPathCredentials), 0644)
-			CreateFileIfNotExists(filepath.Join(pathGardenHome, awsPathConfig), 0644)
-			removeOldEntry(filepath.Join(pathGardenHome, awsPathCredentials), "[gardenctl]")
-			removeOldEntry(filepath.Join(pathGardenHome, awsPathConfig), "[profile gardenctl]")
-			credentials := "[gardenctl]\n" + "aws_access_key_id=" + string(accessKeyID[:]) + "\n" + "aws_secret_access_key=" + string(secretAccessKey[:]) + "\n"
-			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, awsPathCredentials), os.O_APPEND|os.O_WRONLY, 0644)
-			checkError(err)
-			_, err = originalCredentials.WriteString(credentials)
-			checkError(err)
-			originalCredentials.Close()
-			config := "[profile gardenctl]\n" + "region=" + region + "\n" + "output=text\n"
-			originalConfig, err := os.OpenFile(filepath.Join(pathGardenHome, awsPathConfig), os.O_APPEND|os.O_WRONLY, 0644)
-			checkError(err)
-			_, err = originalConfig.WriteString(config)
-			originalConfig.Close()
-			checkError(err)
-		}
 		err := ExecCmd(nil, arguments, false, "AWS_ACCESS_KEY_ID="+string(accessKeyID[:]), "AWS_SECRET_ACCESS_KEY="+string(secretAccessKey[:]), "AWS_DEFAULT_REGION="+region, "AWS_DEFAULT_OUTPUT=text")
 		if err != nil {
 			os.Exit(2)
@@ -121,43 +72,35 @@ func operate(provider, arguments string) {
 		serviceaccount := []byte(secret.Data["serviceaccount.json"])
 		data := map[string]interface{}{}
 		var tmpAccount string
-		if !cachevar {
-			gcpPathCredentials := ""
-			if target.Target[1].Kind == "project" {
-				CreateDir(filepath.Join(pathGardenHome, projectsPath, ".gcp"), 0751)
-				gcpPathCredentials = filepath.Join(projectsPath, ".gcp", "credentials")
-			} else if target.Target[1].Kind == "seed" {
-				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".gcp"), 0751)
-				gcpPathCredentials = filepath.Join(seedsPath, ".gcp", "credentials")
-			}
-			CreateFileIfNotExists(filepath.Join(pathGardenHome, gcpPathCredentials), 0644)
-			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, gcpPathCredentials), os.O_WRONLY, 0644)
-			checkError(err)
-			_, err = originalCredentials.WriteString(string(serviceaccount))
-			originalCredentials.Close()
-			checkError(err)
-			tmpAccount, err = ExecCmdReturnOutput("bash", "-c", "gcloud config list account --format json")
-			if err != nil {
-				fmt.Println("Cmd was unsuccessful")
-				os.Exit(2)
-			}
-			dec := json.NewDecoder(strings.NewReader(tmpAccount))
-			err = dec.Decode(&data)
-			checkError(err)
-			jq := jsonq.NewQuery(data)
-			tmpAccount, err = jq.String("core", "account")
-			if err != nil {
-				os.Exit(2)
-			}
-			err = ExecCmd(nil, "gcloud auth activate-service-account --key-file="+filepath.Join(pathGardenHome, gcpPathCredentials), false)
-			if err != nil {
-				os.Exit(2)
-			}
+
+		tmpFile, err := ioutil.TempFile(os.TempDir(), "tmpFile-")
+		checkError(err)
+		defer os.Remove(tmpFile.Name())
+		 _, err = tmpFile.Write(serviceaccount)
+		checkError(err)
+		err = tmpFile.Close()
+		checkError(err)
+		tmpAccount, err = ExecCmdReturnOutput("bash", "-c", "gcloud config list account --format json")
+		if err != nil {
+			fmt.Println("Cmd was unsuccessful")
+			os.Exit(2)
 		}
-		dec := json.NewDecoder(strings.NewReader(string([]byte(secret.Data["serviceaccount.json"]))))
-		err := dec.Decode(&data)
+		dec := json.NewDecoder(strings.NewReader(tmpAccount))
+		err = dec.Decode(&data)
 		checkError(err)
 		jq := jsonq.NewQuery(data)
+		tmpAccount, err = jq.String("core", "account")
+		if err != nil {
+			os.Exit(2)
+		}
+		err = ExecCmd(nil, "gcloud auth activate-service-account --key-file="+tmpFile.Name(), false)
+		if err != nil {
+			os.Exit(2)
+		}
+		dec = json.NewDecoder(strings.NewReader(string([]byte(secret.Data["serviceaccount.json"]))))
+		err = dec.Decode(&data)
+		checkError(err)
+		jq = jsonq.NewQuery(data)
 		account, err := jq.String("client_email")
 		if err != nil {
 			os.Exit(2)
@@ -174,30 +117,11 @@ func operate(provider, arguments string) {
 		if err != nil {
 			os.Exit(2)
 		}
-
 	case "az":
 		clientID := []byte(secret.Data["clientID"])
 		clientSecret := []byte(secret.Data["clientSecret"])
 		tenantID := []byte(secret.Data["tenantID"])
 		subscriptionID := []byte(secret.Data["subscriptionID"])
-
-		if !cachevar {
-			azurePathCredentials := ""
-			if target.Target[1].Kind == "project" {
-				CreateDir(filepath.Join(pathGardenHome, projectsPath, ".azure"), 0751)
-				azurePathCredentials = filepath.Join(projectsPath, ".azure", "credentials")
-			} else if target.Target[1].Kind == "seed" {
-				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".azure"), 0751)
-				azurePathCredentials = filepath.Join(seedsPath, ".azure", "credentials")
-			}
-			CreateFileIfNotExists(filepath.Join(pathGardenHome, azurePathCredentials), 0644)
-			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, azurePathCredentials), os.O_WRONLY, 0644)
-			checkError(err)
-			credentials := "clientID: " + string(clientID[:]) + "\n" + "clientSecret: " + string(clientSecret[:]) + "\n" + "tenantID: " + string(tenantID[:]) + "\n"
-			_, err = originalCredentials.WriteString(credentials)
-			originalCredentials.Close()
-			checkError(err)
-		}
 		err := ExecCmd(nil, "az login --service-principal -u "+string(clientID[:])+" -p "+string(clientSecret[:])+" --tenant "+string(tenantID[:]), true)
 		if err != nil {
 			os.Exit(2)
@@ -222,23 +146,6 @@ func operate(provider, arguments string) {
 		password := []byte(secret.Data["password"])
 		tenantName := []byte(secret.Data["tenantName"])
 		username := []byte(secret.Data["username"])
-		if !cachevar {
-			openstackPathCredentials := ""
-			if target.Target[1].Kind == "project" {
-				CreateDir(filepath.Join(pathGardenHome, projectsPath, ".openstack"), 0751)
-				openstackPathCredentials = filepath.Join(projectsPath, ".openstack", "credentials")
-			} else if target.Target[1].Kind == "seed" {
-				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".openstack"), 0751)
-				openstackPathCredentials = filepath.Join(seedsPath, ".openstack", "credentials")
-			}
-			CreateFileIfNotExists(filepath.Join(pathGardenHome, openstackPathCredentials), 0644)
-			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, openstackPathCredentials), os.O_WRONLY, 0644)
-			checkError(err)
-			credentials := "authURL: " + authURL + "\n" + "domainName: " + string(domainName[:]) + "\n" + "password: " + string(password[:]) + "\n" + "tenantName: " + string(tenantName[:]) + "\n" + "username: " + string(username[:]) + "\n"
-			_, err = originalCredentials.WriteString(credentials)
-			originalCredentials.Close()
-			checkError(err)
-		}
 		err = ExecCmd(nil, arguments, false, "OS_IDENTITY_API_VERSION=3", "OS_AUTH_VERSION=3", "OS_AUTH_STRATEGY=keystone", "OS_AUTH_URL="+authURL, "OS_TENANT_NAME="+string(tenantName[:]),
 			"OS_PROJECT_DOMAIN_NAME="+string(domainName[:]), "OS_USER_DOMAIN_NAME="+string(domainName[:]), "OS_USERNAME="+string(username[:]), "OS_PASSWORD="+string(password[:]), "OS_REGION_NAME="+region)
 		if err != nil {
@@ -247,35 +154,6 @@ func operate(provider, arguments string) {
 	case "aliyun":
 		accessKeyID := []byte(secret.Data["accessKeyID"])
 		accessKeySecret := []byte(secret.Data["accessKeySecret"])
-		if !cachevar {
-			aliyunPathCredentials := ""
-			aliyunPathConfig := ""
-			if target.Target[1].Kind == "project" {
-				CreateDir(filepath.Join(pathGardenHome, projectsPath, ".aliyun"), 0751)
-				aliyunPathCredentials = filepath.Join(projectsPath, ".aliyun", "credentials")
-				aliyunPathConfig = filepath.Join(projectsPath, ".aliyun", "config")
-			} else if target.Target[1].Kind == "seed" {
-				CreateDir(filepath.Join(pathGardenHome, seedsPath, ".aliyun"), 0751)
-				aliyunPathCredentials = filepath.Join(seedsPath, ".aliyun", "credentials")
-				aliyunPathConfig = filepath.Join(seedsPath, ".aliyun", "config")
-			}
-			CreateFileIfNotExists(filepath.Join(pathGardenHome, aliyunPathCredentials), 0644)
-			CreateFileIfNotExists(filepath.Join(pathGardenHome, aliyunPathConfig), 0644)
-			removeOldEntry(filepath.Join(pathGardenHome, aliyunPathCredentials), "[gardenctl]")
-			removeOldEntry(filepath.Join(pathGardenHome, aliyunPathConfig), "[profile gardenctl]")
-			credentials := "[gardenctl]\n" + "accessKeyId=" + string(accessKeyID[:]) + "\n" + "accessKeySecret=" + string(accessKeySecret[:]) + "\n"
-			originalCredentials, err := os.OpenFile(filepath.Join(pathGardenHome, aliyunPathCredentials), os.O_APPEND|os.O_WRONLY, 0644)
-			checkError(err)
-			defer originalCredentials.Close()
-			_, err = originalCredentials.WriteString(credentials)
-			checkError(err)
-			config := "[profile gardenctl]\n" + "region=" + region + "\n" + "output=json\n"
-			originalConfig, err := os.OpenFile(filepath.Join(pathGardenHome, aliyunPathConfig), os.O_APPEND|os.O_WRONLY, 0644)
-			checkError(err)
-			defer originalConfig.Close()
-			_, err = originalConfig.WriteString(config)
-			checkError(err)
-		}
 		err = ExecCmd(nil, "aliyun configure set --access-key-id="+string(accessKeyID[:])+" --access-key-secret="+string(accessKeySecret[:])+" --region="+region, true)
 		if err != nil {
 			os.Exit(2)


### PR DESCRIPTION
**What this PR does / why we need it**:
For security reasons, pass cloud cli creds once as args on execution only and do not store locally
**Which issue(s) this PR fixes**:
Fixes #243 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
pass cloud cli creds once as args on execution only and do not store locally
```
