### PR TITLE
add restriction support like eu-access restriction

### DIFF
--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -133,9 +133,25 @@ type GardenClusters struct {
 
 // GardenClusterMeta contains name and path to kubeconfig of gardencluster
 type GardenClusterMeta struct {
-	Name         string `yaml:"name,omitempty" json:"name,omitempty"`
-	KubeConfig   string `yaml:"kubeConfig,omitempty" json:"kubeConfig,omitempty"`
-	DashboardURL string `yaml:"dashboardUrl,omitempty" json:"dashboardUrl,omitempty"`
+	Name               string              `yaml:"name,omitempty" json:"name,omitempty"`
+	KubeConfig         string              `yaml:"kubeConfig,omitempty" json:"kubeConfig,omitempty"`
+	DashboardURL       string              `yaml:"dashboardUrl,omitempty" json:"dashboardUrl,omitempty"`
+	AccessRestrictions []AccessRestriction `yaml:"accessRestrictions,omitempty" json:"accessRestrictions,omitempty"`
+}
+
+// AccessRestrictionsOption contains key / notifyIf / msg
+type AccessRestrictionsOption struct {
+	Key      string `yaml:"key,omitempty" json:"key,omitempty"`
+	NotifyIf bool   `yaml:"notifyIf,omitempty" json:"notifyIf,omitempty"`
+	Msg      string `yaml:"msg,omitempty" json:"msg,omitempty"`
+}
+
+// AccessRestriction contains key / notifyIf / msg / options
+type AccessRestriction struct {
+	Key      string                     `yaml:"key,omitempty" json:"key,omitempty"`
+	NotifyIf bool                       `yaml:"notifyIf,omitempty" json:"notifyIf,omitempty"`
+	Msg      string                     `yaml:"msg,omitempty" json:"msg,omitempty"`
+	Options  []AccessRestrictionsOption `yaml:"options,omitempty" json:"options,omitempty"`
 }
 
 // Issues contains all projects with issues


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will display eu-access restriction warning msg in gardenctl terminal if cluster is configed with eu-access and garden config is configed with enabling the eu-access
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/232

**Special notes for your reviewer**:
To use this PR:
1) shoot needs to be configed with eu-access restriction
![image](https://user-images.githubusercontent.com/42594392/89243397-6a67ff80-d636-11ea-9c58-d4caab412f84.png)
2) corresponding garden config needs to be config to enable the eu-access restriction
![image](https://user-images.githubusercontent.com/42594392/89243459-95eaea00-d636-11ea-9909-4db1f8ccde80.png)
3) tests has been perform for following scenario with cross permutation
shoot:
a. config eu-access
b. config node-eu-access
c. addons eu-access
garden config:
a. has/has no access restriction
b. true/false in access restriction key and option key

**Release note**:
```improvement operator
display eu-access restriction warning msg in gardenctl terminal if cluster is configed with eu-access and garden config is configed with enabling the eu-access restriction
```
