### PR TITLE
make non-admin able to target shoot

### DIFF
--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -564,8 +564,8 @@ func targetShoot(targetWriter TargetWriter, shoot gardencorev1beta1.Shoot) {
 	checkError(err)
 	gardenClient, err := target.K8SClientToKind(TargetKindGarden)
 	checkError(err)
-	seedKubeconfigSecret, err := gardenClient.CoreV1().Secrets(seed.Spec.SecretRef.Namespace).Get(seed.Spec.SecretRef.Name, metav1.GetOptions{})
-	checkError(err)
+	seedKubeconfigSecret, _ := gardenClient.CoreV1().Secrets(seed.Spec.SecretRef.Namespace).Get(seed.Spec.SecretRef.Name, metav1.GetOptions{})
+
 	var seedCacheDir = filepath.Join(pathSeedCache, *shoot.Spec.SeedName)
 	err = os.MkdirAll(seedCacheDir, os.ModePerm)
 	checkError(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
make non-garden admin able to target shoots

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/233

**Special notes for your reviewer**:
@petersutter  @wiegandf

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
non garden admin able to target shoots
```
