### PR TITLE
Limit SSH node security group to Bastion IP

### DIFF
--- a/pkg/cmd/ssh_aws.go
+++ b/pkg/cmd/ssh_aws.go
@@ -194,7 +194,7 @@ func (a *AwsInstanceAttribute) createBastionHostSecurityGroup() {
 	fmt.Println("Bastion host security group set up.")
 
 	// add shh rule to ec2 instance
-	arguments = fmt.Sprintf("aws ec2 authorize-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr 0.0.0.0/0", a.SecurityGroupID)
+	arguments = fmt.Sprintf("aws ec2 authorize-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr %s/32", a.SecurityGroupID, a.BastionIP)
 	captured = capture()
 	operate("aws", arguments)
 	_, err = captured()
@@ -336,7 +336,7 @@ func (a *AwsInstanceAttribute) cleanupAwsBastionHost() {
 
 	// remove shh rule from ec2 instance
 	fmt.Println("  (2/3) Close SSH Port on Node.")
-	arguments = fmt.Sprintf("aws ec2 revoke-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr 0.0.0.0/0", a.SecurityGroupID)
+	arguments = fmt.Sprintf("aws ec2 revoke-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr %s/32", a.SecurityGroupID, a.BastionIP)
 	captured = capture()
 	operate("aws", arguments)
 	capturedOutput, err = captured()


### PR DESCRIPTION
**What this PR does / why we need it**:
Limit SSH node security group to Bastion IP
**Which issue(s) this PR fixes**:
Fixes #248 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Limit SSH node security group to Bastion IP
```
