### PR TITLE
add global debug switch and GardenctlDebugLog / GardenctlInfoLog function

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -31,6 +31,7 @@ var outputFormat string
 var gardenConfig string
 var pathGardenHome string
 var sessionID string
+var debugSwitch bool
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -129,6 +130,7 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolVarP(&cachevar, "no-cache", "c", false, "no caching")
 	RootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "yaml", "output format yaml or json")
+	RootCmd.PersistentFlags().BoolVarP(&debugSwitch, "debug", "d", false, "enable debug level output")
 
 	cobra.EnableCommandSorting = false
 	cobra.EnablePrefixMatching = prefixMatching

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardenerlogger "github.com/gardener/gardener/pkg/logger"
 	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
@@ -238,4 +239,18 @@ func CheckShootIsTargeted(target TargetInterface) bool {
 		return false
 	}
 	return true
+}
+
+//GardenctlDebugLog only outputs debug msg when gardencl -d or gardenctl --debug is specified
+func GardenctlDebugLog(logMsg string) {
+	if debugSwitch {
+		var logger = gardenerlogger.NewLogger("debug")
+		logger.Debugf(logMsg)
+	}
+}
+
+//GardenctlInfoLog outputs information msg at all time
+func GardenctlInfoLog(logMsg string) {
+	var logger = gardenerlogger.NewLogger("info")
+	logger.Infof(logMsg)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds 
- global switch `-d` or `--debug` to enable debug logging
- two functions which could be utilized in whole gardenctl project, `GardenctlDebugLog` to output debug msg only when debug switch enabled, `GardenctlInfoLog` to display msg all the time

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/259

**Special notes for your reviewer**:

**Release note**:
```improvement operator
global switch `-d` or `--debug` to enable debug logging, two functions which could be utilized in whole gardenctl project, `GardenctlDebugLog` to output debug msg only when debug switch enabled, `GardenctlInfoLog` to display msg all the time
```
