### PR TITLE
non operator able to target and ssh node through bastion host

### DIFF
--- a/pkg/cmd/download.go
+++ b/pkg/cmd/download.go
@@ -58,6 +58,15 @@ func downloadTerraformFiles(option string) string {
 	namespace := ""
 	var target Target
 	ReadTarget(pathTarget, &target)
+	// return path allow non operator download key file
+	if getRole() == "user" {
+		gardenName := target.Stack()[0].Name
+		projectName := target.Stack()[1].Name
+		shootName := target.Stack()[2].Name
+		pathTerraform := filepath.Join(pathGardenHome, "cache", gardenName, "projects", projectName, shootName)
+		return filepath.Join(pathGardenHome, pathTerraform)
+	}
+
 	var err error
 	Client, err = clientToTarget("garden")
 	checkError(err)
@@ -132,7 +141,7 @@ func downloadTerraformFiles(option string) string {
 	checkError(err)
 	err = ioutil.WriteFile(filepath.Join(pathGardenHome, pathTerraform, "terraform.tfvars"), []byte(secret.Data["terraform.tfvars"]), 0644)
 	checkError(err)
-	return (filepath.Join(pathGardenHome, pathTerraform))
+	return filepath.Join(pathGardenHome, pathTerraform)
 }
 
 func downloadLogs(option string) {

--- a/pkg/cmd/miscellaneous.go
+++ b/pkg/cmd/miscellaneous.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"bufio"
 	"errors"
 	"flag"
 	"fmt"
@@ -116,32 +115,6 @@ func clientToTarget(target TargetKind) (*k8s.Clientset, error) {
 	checkError(err)
 	clientset, err := k8s.NewForConfig(config)
 	return clientset, err
-}
-
-// getShootClusterName returns the clustername of the shoot cluster
-func getShootClusterName() (clustername string) {
-	clustername = ""
-	file, _ := os.Open(getKubeConfigOfCurrentTarget())
-	defer file.Close()
-	scanner := bufio.NewScanner(file)
-	scanner.Split(bufio.ScanLines)
-	for scanner.Scan() {
-		if strings.Contains(scanner.Text(), "current-context:") {
-			clustername = strings.TrimPrefix(scanner.Text(), "current-context: ")
-		}
-	}
-	// retrieve full clustername
-	Client, err := clientToTarget("seed")
-	checkError(err)
-	namespaces, err := Client.CoreV1().Namespaces().List(metav1.ListOptions{})
-	checkError(err)
-	for _, namespace := range namespaces.Items {
-		if strings.HasSuffix(namespace.Name, clustername) {
-			clustername = namespace.Name
-			break
-		}
-	}
-	return clustername
 }
 
 // getMonitoringCredentials returns username and password required for url login to the montiring tools
@@ -357,4 +330,36 @@ func getPublicIP() string {
 	ip, err := ioutil.ReadAll(resp.Body)
 	checkError(err)
 	return string(ip)
+}
+
+// get role either user or operator
+func getRole() string {
+	var role string
+	// will refactor in https://github.com/gardener/gardenctl/issues/266
+	KUBECONFIG = getKubeConfigOfClusterType("garden")
+	out, err := ExecCmdReturnOutput("kubectl", "--kubeconfig="+KUBECONFIG, "auth", "can-i", "get", "secret", "-A")
+	if err == nil {
+		if out == "yes" {
+			role = "operator"
+		}
+	} else {
+		role = "user"
+	}
+	return role
+}
+
+/*
+getTechnicalID returns the Technical Id, which used as clustername of the shoot cluster
+*/
+func getTechnicalID() string {
+	var target Target
+	ReadTarget(pathTarget, &target)
+
+	gardenClientset, err := target.GardenerClient()
+	checkError(err)
+	project, err := gardenClientset.CoreV1beta1().Projects().Get(target.Stack()[1].Name, metav1.GetOptions{})
+	checkError(err)
+	shoot, err := gardenClientset.CoreV1beta1().Shoots(*project.Spec.Namespace).Get(target.Stack()[2].Name, metav1.GetOptions{})
+	checkError(err)
+	return shoot.Status.TechnicalID
 }

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -253,7 +253,7 @@ func showVpnShoot() {
 func showPrometheus() {
 	username, password = getMonitoringCredentials()
 	showPod("prometheus", "seed")
-	output, err := ExecCmdReturnOutput("bash", "-c", "export KUBECONFIG="+KUBECONFIG+"; kubectl get ingress prometheus -n "+getShootClusterName())
+	output, err := ExecCmdReturnOutput("bash", "-c", "export KUBECONFIG="+KUBECONFIG+"; kubectl get ingress prometheus -n "+getTechnicalID())
 	if err != nil {
 		fmt.Println("Cmd was unsuccessful")
 		os.Exit(2)
@@ -275,7 +275,7 @@ func showPrometheus() {
 func showAltermanager() {
 	username, password = getMonitoringCredentials()
 	showPod("alertmanager", "seed")
-	output, err := ExecCmdReturnOutput("bash", "-c", "export KUBECONFIG="+KUBECONFIG+"; kubectl get ingress alertmanager -n "+getShootClusterName())
+	output, err := ExecCmdReturnOutput("bash", "-c", "export KUBECONFIG="+KUBECONFIG+"; kubectl get ingress alertmanager -n "+getTechnicalID())
 	if err != nil {
 		fmt.Println("Cmd was unsuccessful")
 		os.Exit(2)
@@ -352,7 +352,7 @@ func showKubernetesDashboard() {
 func showGrafana() {
 	username, password = getMonitoringCredentials()
 	showPod("grafana", "seed")
-	output, err := ExecCmdReturnOutput("bash", "-c", "export KUBECONFIG="+KUBECONFIG+"; kubectl get ingress grafana -n "+getShootClusterName())
+	output, err := ExecCmdReturnOutput("bash", "-c", "export KUBECONFIG="+KUBECONFIG+"; kubectl get ingress grafana -n "+getTechnicalID())
 	if err != nil {
 		fmt.Println("Cmd was unsuccessful")
 		os.Exit(2)
@@ -382,7 +382,7 @@ func showKibana() {
 	if len(target.Target) == 2 {
 		namespace = "garden"
 	} else if len(target.Target) == 3 {
-		namespace = getShootClusterName()
+		namespace = getTechnicalID()
 	}
 
 	output, err := ExecCmdReturnOutput("bash", "-c", "export KUBECONFIG="+KUBECONFIG+"; kubectl get ingress kibana -n "+namespace)

--- a/pkg/cmd/ssh_alicloud.go
+++ b/pkg/cmd/ssh_alicloud.go
@@ -118,7 +118,7 @@ func sshToAlicloudNode(nodeName, path, user, pathSSKeypair string, sshPublicKey 
 
 // fetchAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName>.
 func (a *AliyunInstanceAttribute) fetchAttributes(nodeName string) {
-	a.ShootName = getShootClusterName()
+	a.ShootName = getTechnicalID()
 	var err error
 	a.InstanceID, err = fetchAlicloudInstanceIDByNodeName(nodeName)
 	checkError(err)
@@ -616,7 +616,7 @@ func cleanupAliyunBastionHost() {
 
 	fmt.Println("")
 	fmt.Println("(2/4) Fetching data from target shoot cluster")
-	a.ShootName = getShootClusterName()
+	a.ShootName = getTechnicalID()
 	a.BastionInstanceName = a.ShootName + "-bastion"
 	a.BastionSecurityGroupName = a.ShootName + "-bsg"
 	fmt.Println("Data fetched from target shoot cluster.")

--- a/pkg/cmd/ssh_azure.go
+++ b/pkg/cmd/ssh_azure.go
@@ -88,7 +88,7 @@ func sshToAZNode(nodeName, path, user, pathSSKeypair string, sshPublicKey []byte
 
 // fetchAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName>.
 func (a *AzureInstanceAttribute) fetchAzureAttributes(nodeName, path string) {
-	a.ShootName = getShootClusterName()
+	a.ShootName = getTechnicalID()
 	a.NamePublicIP = "sshIP"
 	var err error
 

--- a/pkg/cmd/ssh_gcp.go
+++ b/pkg/cmd/ssh_gcp.go
@@ -85,7 +85,7 @@ func sshToGCPNode(nodeName, path, user, pathSSKeypair string, sshPublicKey []byt
 // fetchAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName>.
 func (g *GCPInstanceAttribute) fetchGCPAttributes(nodeName, path string) {
 	var err error
-	g.ShootName = getShootClusterName()
+	g.ShootName = getTechnicalID()
 	g.BastionHostName = g.ShootName + "-bastions"
 	g.FirewallRuleName = g.ShootName + "-allow-ssh-access"
 	g.Subnetwork = g.ShootName + "-nodes"

--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -566,7 +566,15 @@ func targetShoot(targetWriter TargetWriter, shoot gardencorev1beta1.Shoot, reade
 	gardenClient, err := target.K8SClientToKind(TargetKindGarden)
 	checkError(err)
 	seedKubeconfigSecret, err := gardenClient.CoreV1().Secrets(seed.Spec.SecretRef.Namespace).Get(seed.Spec.SecretRef.Name, metav1.GetOptions{})
-	checkError(err)
+	// temporary solution , will clean up code in ticket move get seed out of targetShoot method #269
+	if err != nil {
+		if strings.Contains(err.Error(), "forbidden") {
+			fmt.Printf(warningColor, "\nWarning:\nYou are user role!\n\n")
+		} else {
+			checkError(err)
+		}
+	}
+
 	var seedCacheDir = filepath.Join(pathSeedCache, *shoot.Spec.SeedName)
 	err = os.MkdirAll(seedCacheDir, os.ModePerm)
 	checkError(err)
@@ -676,7 +684,15 @@ func getSeedForProject(shootName string) (seedName string) {
 	gardenClientset, err := gardencoreclientset.NewForConfig(NewConfigFromBytes(*kubeconfig))
 	checkError(err)
 	shootList, err := gardenClientset.CoreV1beta1().Shoots("").List(metav1.ListOptions{})
-	checkError(err)
+	// temporary solution , will clean up code in ticket move get seed out of targetShoot method #269
+	if err != nil {
+		if strings.Contains(err.Error(), "forbidden") {
+			fmt.Printf(warningColor, "\nWarning:\nYou are user role!\n\n")
+		} else {
+			checkError(err)
+		}
+	}
+
 	for _, item := range shootList.Items {
 		if item.Name == shootName {
 			seedName = *item.Spec.SeedName


### PR DESCRIPTION
**What this PR does / why we need it**:
allow non-operator user use project SA account in garden able to manage the shoots in their project via `gardenctl target` and `gardenctl ssh` to list nodes ssh shoot nodes through bastion host. 


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/253
Fixes https://github.com/gardener/gardenctl/issues/233

**Special notes for your reviewer**:
as a request from the end-user currently the `ssh`  only allow access aws provider.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Allow `user` role use Project SA account in garden able to manage the shoots from their own project. `gardenctl ssh` shoot node as well.  `aws`,`gcp`,`azure` supported
```
