### PR TITLE
remove url.QueryEscape

### DIFF
--- a/pkg/cmd/miscellaneous.go
+++ b/pkg/cmd/miscellaneous.go
@@ -351,7 +351,7 @@ func getPublicIP() string {
 	params := url.Values{}
 	params.Add("format", "text")
 	ipURL.RawQuery = params.Encode()
-	resp, err := http.Get(url.QueryEscape(ipURL.String()))
+	resp, err := http.Get(ipURL.String())
 	checkError(err)
 	defer resp.Body.Close()
 	ip, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
**What this PR does / why we need it**:
remove url.QueryEscape

if we have url.QueryEscape(), the url would be "https%3A%2F%2Fapi.ipify.org%3Fformat%3Dtext"
without  url.QueryEscape(), the url would be "https://api.ipify.org?format=text", this is what we want
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/273

**Special notes for your reviewer**:
cc @petersutter 
**Release note**:
```improvement operator

```
