### PR TITLE
Add dashboardUrl and accessRestrictions in sample gardenctl config

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ githubURL: https://github.location.company.corp
 gardenClusters:
 - name: dev
   kubeConfig: ~/clusters/dev/kubeconfig.yaml
+  dashboardUrl: https://url_to_dashboard
+  accessRestrictions:
+  - key: seed.gardener.cloud/eu-access
+    notifyIf: true 
+    msg: warning msg
+    options:
+    - key: support.gardener.cloud/eu-access-for-cluster-addons
+      notifyIf: true
+      msg: warning msg
+    - key: support.gardener.cloud/eu-access-for-cluster-nodes
+      notifyIf: true
+      msg: warning msg
 - name: prod
   kubeConfig: ~/clusters/prod/kubeconfig.yaml
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Update README.md to include dashboardUrl and accessRestrictions in sample gardenctl config
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator

```
