### PR TITLE
fix logic when current stack is garden+seed+namespace

### DIFF
--- a/pkg/cmd/download.go
+++ b/pkg/cmd/download.go
@@ -62,6 +62,10 @@ func downloadTerraformFiles(option string) string {
 	if getRole() == "user" {
 		gardenName := target.Stack()[0].Name
 		projectName := target.Stack()[1].Name
+		if (len(target.Stack()) < 3) || (len(target.Stack()) == 3 && target.Stack()[2].Kind == "namespace") {
+			fmt.Println("No Shoot targeted")
+			os.Exit(2)
+		}
 		shootName := target.Stack()[2].Name
 		pathTerraform := filepath.Join(pathGardenHome, "cache", gardenName, "projects", projectName, shootName)
 		return filepath.Join(pathGardenHome, pathTerraform)
@@ -73,7 +77,7 @@ func downloadTerraformFiles(option string) string {
 	gardenName := target.Stack()[0].Name
 	pathSeedCache := filepath.Join("cache", gardenName, "seeds")
 	pathProjectCache := filepath.Join("cache", gardenName, "projects")
-	if len(target.Stack()) < 3 && (option == "infra" || option == "internal-dns" || option == "external-dns" || option == "ingress" || option == "backup") {
+	if (len(target.Stack()) < 3 && (option == "infra" || option == "internal-dns" || option == "external-dns" || option == "ingress" || option == "backup")) || (len(target.Stack()) == 3 && target.Stack()[2].Kind == "namespace") {
 		fmt.Println("No Shoot targeted")
 		os.Exit(2)
 	} else if len(target.Stack()) < 3 {

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -189,7 +189,7 @@ func runCommand(args []string) {
 func logPod(toMatch string, toTarget string, container string) {
 	var target Target
 	ReadTarget(pathTarget, &target)
-	if len(target.Target) < 3 {
+	if len(target.Target) < 3 || (len(target.Stack()) == 3 && target.Stack()[2].Kind == "namespace") {
 		fmt.Println("No shoot targeted")
 		os.Exit(2)
 	}

--- a/pkg/cmd/show.go
+++ b/pkg/cmd/show.go
@@ -45,7 +45,7 @@ func NewShowCmd() *cobra.Command {
 			checkError(err)
 			err = yaml.Unmarshal(targetFile, &t)
 			checkError(err)
-			if len(t.Target) < 3 && (args[0] != "operator") && (args[0] != "tf") && (args[0] != "kubernetes-dashboard") && (args[0] != "etcd-operator") && (args[0] != "kibana") {
+			if (len(t.Target) < 3 || (len(t.Target) == 3 && t.Stack()[2].Kind == "namespace")) && (args[0] != "operator") && (args[0] != "tf") && (args[0] != "kubernetes-dashboard") && (args[0] != "etcd-operator") && (args[0] != "kibana") {
 				fmt.Println("No shoot targeted")
 				os.Exit(2)
 			} else if (len(t.Target) < 2 && (args[0] == "tf")) || len(t.Target) < 3 && (args[0] == "tf") && (t.Target[1].Kind != "seed") || (len(t.Target) < 2 && (args[0] == "kibana")) {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix `gardenctl download tf infra` reports error when current stack is garden+seed+namespace
same error also exist in `gardenctl logs vpn-seed` and `gardenctl show dashboard`, fixing them together
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/289

**Special notes for your reviewer**:

**Release note**:
```improvement operator
fix `gardenctl download tf infra` reports error when current stack is garden+seed+namespace
```
