### PR TITLE
Fix publicipaddress return

### DIFF
--- a/pkg/cmd/miscellaneous.go
+++ b/pkg/cmd/miscellaneous.go
@@ -315,9 +315,9 @@ func getPublicIP() string {
 	defer resp.Body.Close()
 	ip, err := ioutil.ReadAll(resp.Body)
 	checkError(err)
-	if !isIPv4(string(ip)) {
-		fmt.Println("Not valid ipv4 address")
-		os.Exit(1)
+	if net.ParseIP(string(ip)) == nil {
+		fmt.Printf("IP not valid:" + string(ip))
+		os.Exit(0)
 	}
 	return string(ip)
 }

--- a/pkg/cmd/ssh_aws.go
+++ b/pkg/cmd/ssh_aws.go
@@ -223,13 +223,10 @@ func (a *AwsInstanceAttribute) createBastionHostSecurityGroup() {
 	arguments = fmt.Sprintf("aws ec2 create-tags --resources %s  --tags Key=component,Value=gardenctl", a.BastionSecurityGroupID)
 	operate("aws", arguments)
 
-	if net.IP.To4([]byte(a.MyPublicIP)) != nil {
+	if net.ParseIP(a.MyPublicIP).To4() != nil {
 		arguments = fmt.Sprintf("aws ec2 authorize-security-group-ingress --group-id %s --protocol tcp --port 22 --cidr %s/32", a.BastionSecurityGroupID, a.MyPublicIP)
-	} else if net.IP.To16([]byte(a.MyPublicIP)) != nil {
+	} else if net.ParseIP(a.MyPublicIP).To16() != nil {
 		arguments = fmt.Sprintf("aws ec2 authorize-security-group-ingress --group-id %s --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,Ipv6Ranges=[{CidrIpv6=%s/64}]", a.BastionSecurityGroupID, a.MyPublicIP)
-	} else {
-		fmt.Printf("IP not valid:" + a.MyPublicIP)
-		os.Exit(0)
 	}
 	operate("aws", arguments)
 	fmt.Println("Bastion host security group set up.")


### PR DESCRIPTION
**What this PR does / why we need it**:
fix Public IP to4 and to6 logic return not valid

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/291

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
