### PR TITLE
refactor download/terraform and add test case for download

### DIFF
--- a/pkg/cmd/download.go
+++ b/pkg/cmd/download.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -30,42 +31,45 @@ import (
 )
 
 // NewDownloadCmd returns a new download command.
-func NewDownloadCmd() *cobra.Command {
+func NewDownloadCmd(targetReader TargetReader) *cobra.Command {
 	return &cobra.Command{
 		Use:   "download tf + (infra|internal-dns|external-dns|ingress|backup)\n  gardenctl download logs vpn\n ",
 		Short: "Download terraform configuration/state for local execution for the targeted shoot or log files",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 || !(args[1] == "infra" || args[1] == "internal-dns" || args[1] == "external-dns" || args[1] == "ingress" || args[1] == "backup" || args[1] == "vpn") {
-				fmt.Println("Command must be in the format:\n  download tf + (infra|internal-dns|external-dns|ingress|backup)\n  download logs vpn")
-				os.Exit(2)
+				return errors.New("Command must be in the format:\n  download tf + (infra|internal-dns|external-dns|ingress|backup)\n  download logs vpn")
 			}
 			switch args[0] {
 			case "tf":
-				path := downloadTerraformFiles(args[1])
+				path := downloadTerraformFiles(args[1], targetReader)
 				fmt.Println("Downloaded to " + path)
 			case "logs":
-				downloadLogs(args[1])
+				downloadLogs(args[1], targetReader)
 			default:
 				fmt.Println("Command must be in the format:\n  download tf + (infra|internal-dns|external-dns|ingress|backup)\n  download logs vpn")
 			}
+			return nil
 		},
 		ValidArgs: []string{"tf"},
 	}
 }
 
 // downloadTerraformFiles downloads the corresponding tf file
-func downloadTerraformFiles(option string) string {
+func downloadTerraformFiles(option string, targetReader TargetReader) string {
 	namespace := ""
-	var target Target
-	ReadTarget(pathTarget, &target)
+	target := targetReader.ReadTarget(pathTarget)
 	// return path allow non operator download key file
 	if getRole() == "user" {
-		gardenName := target.Stack()[0].Name
-		projectName := target.Stack()[1].Name
 		if (len(target.Stack()) < 3) || (len(target.Stack()) == 3 && target.Stack()[2].Kind == "namespace") {
 			fmt.Println("No Shoot targeted")
 			os.Exit(2)
+		} else if target.Stack()[1].Kind == "seed" {
+			fmt.Println("Currently target stack is garden/seed/shoot which doesn't allow user role to access shoot via seed")
+			fmt.Println("Please target shoot via `gardenctl target shoot` directly or target shoot via project")
+			os.Exit(2)
 		}
+		gardenName := target.Stack()[0].Name
+		projectName := target.Stack()[1].Name
 		shootName := target.Stack()[2].Name
 		pathTerraform := filepath.Join(pathGardenHome, "cache", gardenName, "projects", projectName, shootName)
 		return filepath.Join(pathGardenHome, pathTerraform)
@@ -122,20 +126,20 @@ func downloadTerraformFiles(option string) string {
 		Client, err = k8s.NewForConfig(config)
 		checkError(err)
 	}
-	cmTfConfig, err := Client.CoreV1().ConfigMaps(namespace).Get((target.Target[2].Name + "." + option + ".tf-config"), metav1.GetOptions{})
+	cmTfConfig, err := Client.CoreV1().ConfigMaps(namespace).Get((target.Stack()[2].Name + "." + option + ".tf-config"), metav1.GetOptions{})
 	checkError(err)
-	cmTfState, err := Client.CoreV1().ConfigMaps(namespace).Get((target.Target[2].Name + "." + option + ".tf-state"), metav1.GetOptions{})
+	cmTfState, err := Client.CoreV1().ConfigMaps(namespace).Get((target.Stack()[2].Name + "." + option + ".tf-state"), metav1.GetOptions{})
 	checkError(err)
-	secret, err := Client.CoreV1().Secrets(namespace).Get((target.Target[2].Name + "." + option + ".tf-vars"), metav1.GetOptions{})
+	secret, err := Client.CoreV1().Secrets(namespace).Get((target.Stack()[2].Name + "." + option + ".tf-vars"), metav1.GetOptions{})
 	checkError(err)
 	pathTerraform := ""
-	if target.Target[1].Kind == "project" {
-		CreateDir(filepath.Join(pathGardenHome, pathProjectCache, target.Target[1].Name, target.Target[2].Name, "terraform"), 0751)
-		pathTerraform = filepath.Join("cache", gardenName, "projects", target.Target[1].Name, target.Target[2].Name, "terraform")
+	if target.Stack()[1].Kind == "project" {
+		CreateDir(filepath.Join(pathGardenHome, pathProjectCache, target.Stack()[1].Name, target.Stack()[2].Name, "terraform"), 0751)
+		pathTerraform = filepath.Join("cache", gardenName, "projects", target.Stack()[1].Name, target.Stack()[2].Name, "terraform")
 
-	} else if target.Target[1].Kind == "seed" {
-		CreateDir(filepath.Join(pathGardenHome, pathSeedCache, target.Target[1].Name, target.Target[2].Name, "terraform"), 0751)
-		pathTerraform = filepath.Join("cache", gardenName, "seeds", target.Target[1].Name, target.Target[2].Name, "terraform")
+	} else if target.Stack()[1].Kind == "seed" {
+		CreateDir(filepath.Join(pathGardenHome, pathSeedCache, target.Stack()[1].Name, target.Stack()[2].Name, "terraform"), 0751)
+		pathTerraform = filepath.Join("cache", gardenName, "seeds", target.Stack()[1].Name, target.Stack()[2].Name, "terraform")
 	}
 	err = ioutil.WriteFile(filepath.Join(pathGardenHome, pathTerraform, "main.tf"), []byte(cmTfConfig.Data["main.tf"]), 0644)
 	checkError(err)
@@ -148,11 +152,10 @@ func downloadTerraformFiles(option string) string {
 	return filepath.Join(pathGardenHome, pathTerraform)
 }
 
-func downloadLogs(option string) {
+func downloadLogs(option string, targetReader TargetReader) {
 	dir, err := os.Getwd()
 	checkError(err)
-	var target Target
-	ReadTarget(pathTarget, &target)
+	target := targetReader.ReadTarget(pathTarget)
 	Client, err = clientToTarget("garden")
 	checkError(err)
 	gardenName := target.Stack()[0].Name

--- a/pkg/cmd/download_test.go
+++ b/pkg/cmd/download_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_test
+
+import (
+	"github.com/gardener/gardenctl/pkg/cmd"
+	mockcmd "github.com/gardener/gardenctl/pkg/mock/cmd"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+var _ = Describe("Download command", func() {
+	var (
+		ctrl         *gomock.Controller
+		targetReader *mockcmd.MockTargetReader
+		target       *mockcmd.MockTargetInterface
+		command      *cobra.Command
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		targetReader = mockcmd.NewMockTargetReader(ctrl)
+		target = mockcmd.NewMockTargetInterface(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("with invalid number of args", func() {
+		It("should return error", func() {
+			targetReader.EXPECT().ReadTarget(gomock.Any()).Return(target).AnyTimes()
+			target.EXPECT().Stack().Return([]cmd.TargetMeta{}).AnyTimes()
+			command = cmd.NewDownloadCmd(targetReader)
+			command.SetArgs([]string{})
+			err := command.Execute()
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Command must be in the format:\n  download tf + (infra|internal-dns|external-dns|ingress|backup)\n  download logs vpn"))
+		})
+	})
+})

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -141,7 +141,7 @@ func init() {
 		NewTargetCmd(targetReader, targetWriter, configReader, ioStreams, kubeconfigReader),
 		NewDropCmd(targetReader, targetWriter, ioStreams),
 		NewGetCmd(targetReader, configReader, kubeconfigReader, kubeconfigWriter, ioStreams))
-	RootCmd.AddCommand(NewDownloadCmd(), NewShowCmd(), NewLogsCmd())
+	RootCmd.AddCommand(NewDownloadCmd(targetReader), NewShowCmd(), NewLogsCmd())
 	RootCmd.AddCommand(NewRegisterCmd(), NewUnregisterCmd())
 	RootCmd.AddCommand(NewCompletionCmd())
 	RootCmd.AddCommand(NewShellCmd(targetReader, ioStreams))

--- a/pkg/cmd/ssh.go
+++ b/pkg/cmd/ssh.go
@@ -56,7 +56,7 @@ func NewSSHCmd(reader TargetReader, ioStreams IOStreams) *cobra.Command {
 				return printNodeNames(shoot.Name)
 			}
 
-			path := downloadTerraformFiles("infra")
+			path := downloadTerraformFiles("infra", reader)
 			if path != "" {
 				path = filepath.Join(path, "terraform.tfstate")
 			}

--- a/pkg/cmd/terraform.go
+++ b/pkg/cmd/terraform.go
@@ -37,7 +37,7 @@ func NewTerraformCmd(targetReader TargetReader) *cobra.Command {
 			}
 
 			arguments := "terraform " + strings.Join(args[:], " ")
-			terraform(arguments)
+			terraform(arguments, targetReader)
 
 			return nil
 		},
@@ -45,25 +45,24 @@ func NewTerraformCmd(targetReader TargetReader) *cobra.Command {
 }
 
 // terraform executes a terraform command on targeted cluster
-func terraform(args string) {
+func terraform(args string, targetReader TargetReader) {
 	_, err := exec.LookPath("terraform")
 	if err != nil {
 		fmt.Println("Terraform is not installed on your system")
 		os.Exit(2)
 	}
-	var target Target
-	ReadTarget(pathTarget, &target)
+	target := targetReader.ReadTarget(pathTarget)
 	gardenName := target.Stack()[0].Name
 	pathTerraform := ""
 
-	if target.Target[1].Kind == "project" {
-		pathTerraform = filepath.Join(pathGardenHome, "cache", gardenName, "projects", target.Target[1].Name, target.Target[2].Name, "terraform")
-	} else if target.Target[1].Kind == "seed" {
-		pathTerraform = filepath.Join(pathGardenHome, "cache", gardenName, "seeds", target.Target[1].Name, target.Target[2].Name, "terraform")
+	if target.Stack()[1].Kind == "project" {
+		pathTerraform = filepath.Join(pathGardenHome, "cache", gardenName, "projects", target.Stack()[1].Name, target.Stack()[2].Name, "terraform")
+	} else if target.Stack()[1].Kind == "seed" {
+		pathTerraform = filepath.Join(pathGardenHome, "cache", gardenName, "seeds", target.Stack()[1].Name, target.Stack()[2].Name, "terraform")
 	}
 
 	if strings.HasSuffix(args, "init") {
-		pathTerraform = downloadTerraformFiles("infra")
+		pathTerraform = downloadTerraformFiles("infra", targetReader)
 		fmt.Println("Downloaded terraform config to " + pathTerraform)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains things from many aspect:
- [x]  part of https://github.com/gardener/gardenctl/issues/307, contains refactor for `download` / `terraform`
- [x] added test case for `download`, in oder to make `download.go` to be testable i also make some modification to `download.go`
- [x] when `getRole() == "user"` , we can't assume current stack is `garden/project/shoot`, we should add check and fail the process when current stack is `garden/seed/shoot` , see https://github.com/gardener/gardenctl/compare/master...neo-liang-sap:download-test?expand=1#diff-5ea91c3cc672b9d1b4df67072a980d4aR66 , @tedteng FYI
- [x] as download.go involves terraform related actions, i also modified terraform.go, @jfortin-sap FYI
- [x] ssh.go is modified as ssh also involves terraform related action

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/306

**Special notes for your reviewer**:

**Release note**:
```improvement operator
```
