### PR TITLE
refactor target.go to prevent user role for targeting seed

### DIFF
--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -599,18 +599,21 @@ func targetShoot(targetWriter TargetWriter, shoot gardencorev1beta1.Shoot, reade
 		target.Target = append(target.Target, TargetMeta{"shoot", shoot.Name})
 	} else if len(target.Target) == 2 {
 		drop(targetWriter)
-		if target.Target[1].Kind == "seed" {
+		if target.Target[1].Kind == "seed" && getRole() != "user" {
 			target.Target[1].Kind = "seed"
 			target.Target[1].Name = *shoot.Spec.SeedName
 		} else if target.Target[1].Kind == "project" {
 			target.Target[1].Kind = "project"
 			target.Target[1].Name = projectName
+		} else {
+			fmt.Println("You are user role and can't target shoot via seed, please target shoot via project")
+			os.Exit(2)
 		}
 		target.Target = append(target.Target, TargetMeta{"shoot", shoot.Name})
 	} else if len(target.Target) == 3 {
 		drop(targetWriter)
 		drop(targetWriter)
-		if len(target.Target) > 2 && target.Target[1].Kind == "seed" {
+		if len(target.Target) > 2 && target.Target[1].Kind == "seed" && getRole() != "user" {
 			target.Target = target.Target[:len(target.Target)-2]
 			target.Target = append(target.Target, TargetMeta{"seed", *shoot.Spec.SeedName})
 			target.Target = append(target.Target, TargetMeta{"shoot", shoot.Name})
@@ -618,12 +621,15 @@ func targetShoot(targetWriter TargetWriter, shoot gardencorev1beta1.Shoot, reade
 			target.Target = target.Target[:len(target.Target)-2]
 			target.Target = append(target.Target, TargetMeta{"project", projectName})
 			target.Target = append(target.Target, TargetMeta{"shoot", shoot.Name})
+		} else {
+			fmt.Println("You are user role and can't target shoot via seed, please target shoot via project")
+			os.Exit(2)
 		}
 	} else if len(target.Target) == 4 {
 		drop(targetWriter)
 		drop(targetWriter)
 		drop(targetWriter)
-		if len(target.Target) > 3 && target.Target[1].Kind == "seed" {
+		if len(target.Target) > 3 && target.Target[1].Kind == "seed" && getRole() != "user" {
 			target.Target = target.Target[:len(target.Target)-3]
 			target.Target = append(target.Target, TargetMeta{"seed", *shoot.Spec.SeedName})
 			target.Target = append(target.Target, TargetMeta{"shoot", shoot.Name})
@@ -631,6 +637,9 @@ func targetShoot(targetWriter TargetWriter, shoot gardencorev1beta1.Shoot, reade
 			target.Target = target.Target[:len(target.Target)-3]
 			target.Target = append(target.Target, TargetMeta{"project", projectName})
 			target.Target = append(target.Target, TargetMeta{"shoot", shoot.Name})
+		} else {
+			fmt.Println("You are user role and can't target shoot via seed, please target shoot via project")
+			os.Exit(2)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
when getRole() == "user", prevent user from targeting seed as user don't have permission on seed
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/309

**Special notes for your reviewer**:

**Release note**:
```improvement operator
when getRole() == "user", prevent user from targeting seed as user don't have permission on seed
```
