### PR TITLE
refactor getTechnicalID

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -39,7 +39,6 @@ func NewGetCmd(targetReader TargetReader, configReader ConfigReader,
 			if len(args) < 1 || len(args) > 2 {
 				return errors.New("command must be in the format: get [(garden|project|seed|shoot|target) <name>]")
 			}
-
 			switch args[0] {
 			case "project":
 				if len(args) == 1 {

--- a/pkg/cmd/infra.go
+++ b/pkg/cmd/infra.go
@@ -113,7 +113,7 @@ func GetOrphanInfraResources(rs []string, terraformstate string) error {
 
 func getAWSInfraResources() []string {
 	rs := make([]string, 0)
-	shoottag := getTechnicalID()
+	shoottag := getFromTargetInfo("shootTechnicalID")
 
 	// fetch shoot vpc resources
 	capturedOutput := execInfraOperator("aws", "aws ec2 describe-vpcs --filter Name=tag:kubernetes.io/cluster/"+shoottag+",Values=1")
@@ -165,7 +165,7 @@ func getAWSInfraResources() []string {
 
 func getAzureInfraResources() []string {
 	rs := make([]string, 0)
-	shoottag := getTechnicalID()
+	shoottag := getFromTargetInfo("shootTechnicalID")
 
 	// fetch shoot resource group
 	capturedOutput := execInfraOperator("az", "az group show --name "+shoottag)
@@ -204,7 +204,7 @@ func getAzureInfraResources() []string {
 
 func getGCPInfraResources() []string {
 	rs := make([]string, 0)
-	shoottag := getTechnicalID()
+	shoottag := getFromTargetInfo("shootTechnicalID")
 
 	// fetch shoot subnet resource
 	capturedOutput := execInfraOperator("gcp", "gcloud compute networks subnets list")

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -189,12 +189,7 @@ func logPod(toMatch string, toTarget string, container string) {
 	}
 	namespace := getSeedNamespaceNameForShoot(target.Target[2].Name)
 	var err error
-
-	project, err := getProjectForShoot()
-	checkError(err)
-	shootName := target.Target[2].Name
-
-	shoot, err := Client.GardenerV1beta1().Shoots(*project.Spec.Namespace).Get(shootName, metav1.GetOptions{})
+	shoot, err := getShootObject()
 	checkError(err)
 
 	gardenerVersion, err := semver.NewVersion(shoot.Status.Gardener.Version)
@@ -311,7 +306,9 @@ func logPodGardenImproved(podName string) {
 	checkError(err)
 	pods, err := Client.CoreV1().Pods("garden").List(metav1.ListOptions{})
 	checkError(err)
-	project, err := getProjectForShoot()
+	project, err := getTargetName("project")
+	checkError(err)
+	shootName, err := getTargetName("shoot")
 	checkError(err)
 
 	for _, pod := range pods.Items {
@@ -323,7 +320,7 @@ func logPodGardenImproved(podName string) {
 			}
 			lines := strings.Split("time="+output, `time=`)
 			for _, line := range lines {
-				if strings.Contains(line, ("shoot=" + project.Name + "/" + target.Target[2].Name)) {
+				if strings.Contains(line, ("shoot=" + project + "/" + shootName)) {
 					fmt.Print(line)
 				}
 			}

--- a/pkg/cmd/miscellaneous.go
+++ b/pkg/cmd/miscellaneous.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -164,29 +165,38 @@ func getSeedNamespaceNameForShoot(shootName string) (namespaceSeed string) {
 	return shoot.Status.TechnicalID
 }
 
-// getProjectForShoot returns the Project for Shoot
-func getProjectForShoot() (v1beta1.Project, error) {
+//getProjectObject returns the Project for Shoot
+func getProjectObject() (*v1beta1.Project, error) {
 	var target Target
-	project := v1beta1.Project{}
 	ReadTarget(pathTarget, &target)
-	Client, err := clientToTarget("garden")
+	Client, err := target.K8SClientToKind("garden")
 	checkError(err)
-	if target.Target[1].Kind == "project" {
-		projectName := target.Target[1].Name
-		p, err := Client.GardenerV1beta1().Projects().Get(projectName, metav1.GetOptions{})
+
+	if isTargeted("project") {
+		projectName, err := getTargetName("project")
 		checkError(err)
-		project = *p
-	} else {
+		return Client.GardenerV1beta1().Projects().Get(projectName, metav1.GetOptions{})
+	} else if isTargeted("seed", "shoot") {
+		if getRole() == "user" {
+			return nil, errors.New("can't determine project. Target project instead of seed")
+		}
+		seedName, err := getTargetName("seed")
+		checkError(err)
+		shootName, err := getTargetName("shoot")
+		checkError(err)
+
 		shootList, err := Client.GardenerV1beta1().Shoots(metav1.NamespaceAll).List(metav1.ListOptions{
 			FieldSelector: fields.SelectorFromSet(
 				fields.Set{
-					core.ShootSeedName: target.Target[1].Name,
-					"metadata.name":    target.Target[2].Name,
+					core.ShootSeedName: seedName,
+					"metadata.name":    shootName,
 				}).String(),
 		})
 		checkError(err)
-		if len(shootList.Items) != 1 {
-			return project, errors.New("there are multiple shoots with the same name running on the same seed")
+		if len(shootList.Items) == 0 {
+			return nil, errors.New("No shoot found with name " + shootName + " that is running on the seed " + seedName)
+		} else if len(shootList.Items) > 1 {
+			return nil, errors.New("There are multiple shoots with the name " + shootName + " that are running on the seed " + seedName)
 		}
 		projectNamespace := shootList.Items[0].Namespace
 
@@ -195,13 +205,27 @@ func getProjectForShoot() (v1beta1.Project, error) {
 
 		for _, p := range projectList.Items {
 			if *p.Spec.Namespace == projectNamespace {
-				project = p
-				break
+				return &p, nil
 			}
 		}
 	}
 
-	return project, nil
+	return nil, errors.New("can't determine project")
+}
+
+//getShootObject return shoot object and error
+func getShootObject() (*v1beta1.Shoot, error) {
+	var target Target
+	ReadTarget(pathTarget, &target)
+	gardenClientset, err := target.GardenerClient()
+	checkError(err)
+	project, err := getProjectObject()
+	checkError(err)
+	shootName, err := getTargetName("shoot")
+	checkError(err)
+	shoot, err := gardenClientset.CoreV1beta1().Shoots(*project.Spec.Namespace).Get(shootName, metav1.GetOptions{})
+	checkError(err)
+	return shoot, nil
 }
 
 // getTargetType returns error and name of type
@@ -328,17 +352,78 @@ func getRole() string {
 }
 
 /*
-getTechnicalID returns the Technical Id, which used as clustername of the shoot cluster
+getTargetMapInfo retun garden,project,seed,shoot,shootTechnicalID to global targetInfo
+Use `getFromTargetInfo()` instead
 */
-func getTechnicalID() string {
+func getTargetMapInfo() {
+	if len(targetInfo) > 0 {
+		return
+	}
+	var target Target
+	ReadTarget(pathTarget, &target)
+	for _, t := range target.Stack() {
+		targetInfo[string(t.Kind)] = string(t.Name)
+	}
+
+	if isTargeted("shoot") {
+		shoot, err := getShootObject()
+		checkError(err)
+		targetInfo["shootTechnicalID"] = shoot.Status.TechnicalID
+
+		if targetInfo["seed"] == "" {
+			targetInfo["seed"] = *shoot.Spec.SeedName
+		}
+	}
+
+	if targetInfo["project"] == "" {
+		projectObj, err := getProjectObject()
+		checkError(err)
+		targetInfo["project"] = projectObj.Name
+	}
+}
+
+/*
+lookup Target Kind ("kind value") return Target Name "name value" from target file ~/.garden/sessions/plantingSession/target
+*/
+func getTargetName(Kind string) (string, error) {
+	var target Target
+	ReadTarget(pathTarget, &target)
+	for _, t := range target.Stack() {
+		if string(t.Kind) == Kind {
+			return string(t.Name), nil
+		}
+	}
+	return "", errors.New("Kind:" + Kind + "not found from ~/.garden/sessions/plantingSession/target")
+}
+
+/*
+check if target Kind is exist in target file ~/.garden/sessions/plantingSession/target
+*/
+func isTargeted(args ...string) bool {
 	var target Target
 	ReadTarget(pathTarget, &target)
 
-	gardenClientset, err := target.GardenerClient()
-	checkError(err)
-	project, err := gardenClientset.CoreV1beta1().Projects().Get(target.Stack()[1].Name, metav1.GetOptions{})
-	checkError(err)
-	shoot, err := gardenClientset.CoreV1beta1().Shoots(*project.Spec.Namespace).Get(target.Stack()[2].Name, metav1.GetOptions{})
-	checkError(err)
-	return shoot.Status.TechnicalID
+	targetMap := make(map[string]interface{})
+	for _, t := range target.Stack() {
+		targetMap[string(t.Kind)] = string(t.Name)
+	}
+
+	for _, t := range args {
+		if _, ok := targetMap[t]; ok {
+		} else {
+			return false
+		}
+	}
+
+	return true
+}
+
+//getFromTargetInfo validation value from global map targetInfo garden/project/shoot/seed/shootTechnicalID/....
+func getFromTargetInfo(key string) string {
+	getTargetMapInfo()
+	value := targetInfo[key]
+	if value == "" {
+		log.Fatalf("value %s not found in targetInfo\n", key)
+	}
+	return value
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -32,6 +32,7 @@ var gardenConfig string
 var pathGardenHome string
 var sessionID string
 var debugSwitch bool
+var targetInfo = make(map[string]string)
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{

--- a/pkg/cmd/ssh_alicloud.go
+++ b/pkg/cmd/ssh_alicloud.go
@@ -118,7 +118,7 @@ func sshToAlicloudNode(nodeName, path, user, pathSSKeypair string, sshPublicKey 
 
 // fetchAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName>.
 func (a *AliyunInstanceAttribute) fetchAttributes(nodeName string) {
-	a.ShootName = getTechnicalID()
+	a.ShootName = getFromTargetInfo("shootTechnicalID")
 	var err error
 	a.InstanceID, err = fetchAlicloudInstanceIDByNodeName(nodeName)
 	checkError(err)
@@ -616,7 +616,7 @@ func cleanupAliyunBastionHost() {
 
 	fmt.Println("")
 	fmt.Println("(2/4) Fetching data from target shoot cluster")
-	a.ShootName = getTechnicalID()
+	a.ShootName = getFromTargetInfo("shootTechnicalID")
 	a.BastionInstanceName = a.ShootName + "-bastion"
 	a.BastionSecurityGroupName = a.ShootName + "-bsg"
 	fmt.Println("Data fetched from target shoot cluster.")

--- a/pkg/cmd/ssh_aws.go
+++ b/pkg/cmd/ssh_aws.go
@@ -109,7 +109,7 @@ func sshToAWSNode(nodeName, path, user, pathSSKeypair string, sshPublicKey []byt
 
 // fetchAwsAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName> by using aws cli for non-operator user
 func (a *AwsInstanceAttribute) fetchAwsAttributesByCLI(nodeName, path string) {
-	a.ShootName = getTechnicalID()
+	a.ShootName = getFromTargetInfo("shootTechnicalID")
 	publicUtility := a.ShootName + "-public-utility-z0"
 	arguments := fmt.Sprintf("aws ec2 describe-subnets --filters Name=tag:Name,Values=" + publicUtility + " --query Subnets[*].SubnetId")
 	captured := capture()
@@ -143,7 +143,7 @@ func (a *AwsInstanceAttribute) fetchAwsAttributesByCLI(nodeName, path string) {
 
 // fetchAwsAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName>.
 func (a *AwsInstanceAttribute) fetchAwsAttributes(nodeName, path string) {
-	a.ShootName = getTechnicalID()
+	a.ShootName = getFromTargetInfo("shootTechnicalID")
 
 	yamlData, err := ioutil.ReadFile(path)
 	checkError(err)

--- a/pkg/cmd/ssh_azure.go
+++ b/pkg/cmd/ssh_azure.go
@@ -91,7 +91,7 @@ func sshToAZNode(nodeName, path, user, pathSSKeypair string, sshPublicKey []byte
 
 // fetchAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName>.
 func (a *AzureInstanceAttribute) fetchAzureAttributes(nodeName, path string) {
-	a.ShootName = getTechnicalID()
+	a.ShootName = getFromTargetInfo("shootTechnicalID")
 	a.NamePublicIP = "sshIP"
 	var err error
 

--- a/pkg/cmd/ssh_gcp.go
+++ b/pkg/cmd/ssh_gcp.go
@@ -99,7 +99,7 @@ func sshToGCPNode(nodeName, path, user, pathSSKeypair string, sshPublicKey []byt
 // fetchAwsAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName> by using gcp cli for non-operator user
 func (g *GCPInstanceAttribute) fetchGCPAttributesByCLI(nodeName, path string) {
 	var err error
-	g.ShootName = getTechnicalID()
+	g.ShootName = getFromTargetInfo("shootTechnicalID")
 	g.BastionHostName = g.ShootName + "-bastions"
 	g.FirewallRuleName = g.ShootName + "-allow-ssh-access"
 	g.Subnetwork = g.ShootName + "-nodes"
@@ -122,7 +122,7 @@ func (g *GCPInstanceAttribute) fetchGCPAttributesByCLI(nodeName, path string) {
 // fetchAttributes gets all the needed attributes for creating bastion host and its security group with given <nodeName>.
 func (g *GCPInstanceAttribute) fetchGCPAttributes(nodeName, path string) {
 	var err error
-	g.ShootName = getTechnicalID()
+	g.ShootName = getFromTargetInfo("shootTechnicalID")
 	g.BastionHostName = g.ShootName + "-bastions"
 	g.FirewallRuleName = g.ShootName + "-allow-ssh-access"
 	g.Subnetwork = g.ShootName + "-nodes"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/312

**Special notes for your reviewer**:
@petersutter base on #317 I just enhanced the code and introduce some new methods 
`getTargetMapInfo `, will executed once then fetch all the information save to the global variable 
`isTargetFilsHas`,`lookupTargetNameFromKind` .  That's the new one and my favourite too. It may user for replace the usage of target[0].Name and judgement of target.Target belong to garden/project/seed/shoot/...  I am planning use those methods for refacor target.go https://github.com/gardener/gardenctl/issues/269 later and it is more readable as well. 

let me know any concerns and welcome any feedback. especially, the new methods, whether have defects or use more meaningful method name. 
 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
