### PR TITLE
Fix getRole

### DIFF
--- a/pkg/cmd/miscellaneous.go
+++ b/pkg/cmd/miscellaneous.go
@@ -335,7 +335,7 @@ func getRole() string {
 		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Verb:     "get",
-				Resource: "secret",
+				Resource: "secrets",
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes issue that getRole does not return the correct value in case an oidc user configuration is used within the kubeconfig

**Which issue(s) this PR fixes**:
Fixes #330

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
