### PR TITLE
fix ssh oidc issue

### DIFF
--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -173,7 +173,7 @@ func NewConfigFromBytes(kubeconfig string) *restclient.Config {
 // ValidateClientConfig validates that the auth info of a given kubeconfig doesn't have unsupported fields.
 func ValidateClientConfig(config clientcmdapi.Config) error {
 	validFields := []string{"client-certificate-data", "client-key-data", "token", "username", "password"}
-	pathOfKubeconfig := getKubeConfigOfCurrentTarget()
+	// pathOfKubeconfig := getKubeConfigOfCurrentTarget()
 	for user, authInfo := range config.AuthInfos {
 		switch {
 		case authInfo.ClientCertificate != "":
@@ -185,11 +185,11 @@ func ValidateClientConfig(config clientcmdapi.Config) error {
 		case authInfo.Impersonate != "" || len(authInfo.ImpersonateGroups) > 0:
 			return fmt.Errorf("impersonation is not supported, these are the valid fields: %+v", validFields)
 		case authInfo.AuthProvider != nil && len(authInfo.AuthProvider.Config) > 0:
-			fmt.Printf("Kubeconfig under path %s contains auth provider configurations that could contain malicious code. Please only continue if you have verified it to be uncritical\n", pathOfKubeconfig)
+			// fmt.Printf("Kubeconfig under path %s contains auth provider configurations that could contain malicious code. Please only continue if you have verified it to be uncritical\n", pathOfKubeconfig)
 			return nil
 			// 	return fmt.Errorf("auth provider configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
 		case authInfo.Exec != nil:
-			fmt.Printf("Kubeconfig under path %s contains exec configurations that could contain malicious code. Please only continue if you have verified it to be uncritical\n", pathOfKubeconfig)
+			// fmt.Printf("Kubeconfig under path %s contains exec configurations that could contain malicious code. Please only continue if you have verified it to be uncritical\n", pathOfKubeconfig)
 			return nil
 			// 	return fmt.Errorf("exec configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix ssh oidc wariming msg block ssh issue

due to the oidc warming msg, the capture() will return more information cause the issue. for a quick fix. I comments the print. let me know if any issue then will take time wokring on later

``` 
"Kubeconfig under path /Users/i333878/.garden/cache/canary/projects/i333878/aws-users-role/kubeconfig.yaml contains exec configurations that could contain malicious code. Please only continue if you have verified it to be uncritical
sg-09527df1718b9a7b0
"
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/322

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
fix ssh oidc wariming msg block ssh issue
```