### PR TITLE
add github action to auto update ops-toolbelt

### DIFF
--- a/.github/workflows/update-gardenctl.yml
+++ b/.github/workflows/update-gardenctl.yml
@@ -31,3 +31,10 @@ jobs:
           -H 'Accept: application/vnd.github.everest-preview+json' \
           -u ${{ secrets.ACCESS_TOKEN }} \
           --data '{"event_type": "update", "client_payload": { "tag": "'"${{ steps.build_binary_files.outputs.latest_release_filtered_tag }}"'", "mac_sha": "'"$mac_sha256sum"'", "linux_sha": "'"$linux_sha256sum"'"}}'
+      - name: Send update with latest versions to gardener/ops-toolbelt
+        run: |
+          echo '{"event_type": "update", "client_payload": { "tag": "'"${{ steps.build_binary_files.outputs.latest_release_filtered_tag }}"'"}}'
+          curl -X POST https://api.github.com/repos/gardener/ops-toolbelt/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.ACCESS_TOKEN }} \
+          --data '{"event_type": "update", "client_payload": { "tag": "'"${{ steps.build_binary_files.outputs.latest_release_filtered_tag }}"'"}}'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements auto integration between gardenctl and ops-toolbelt, when a new version of gardenctl released, version in ops-toolbelt is also updated
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/336

**Special notes for your reviewer**:
this PR needs to be co-work with https://github.com/gardener/ops-toolbelt/pull/34
**Release note**:
```improvement operator
Auto integration between gardenctl and ops-toolbelt, when a new version of gardenctl released, version in ops-toolbelt is also updated
```
