### PR TITLE
hotfix to https://github.com/gardener/gardenctl/issues/389

### DIFF
--- a/pkg/cmd/operate.go
+++ b/pkg/cmd/operate.go
@@ -88,6 +88,7 @@ func operate(provider, arguments string) string {
 		accessKeyID := []byte(secret.Data["accessKeyID"])
 		secretAccessKey := []byte(secret.Data["secretAccessKey"])
 		args := strings.Fields(arguments)
+		args = args[1:]
 		cmd := exec.Command("aws", args...)
 		newEnv := append(os.Environ(), "AWS_ACCESS_KEY_ID="+string(accessKeyID[:]), "AWS_SECRET_ACCESS_KEY="+string(secretAccessKey[:]), "AWS_DEFAULT_REGION="+region, "AWS_DEFAULT_OUTPUT=text")
 		cmd.Env = newEnv
@@ -95,6 +96,7 @@ func operate(provider, arguments string) string {
 		if err != nil {
 			log.Fatalf("AWS CLI failed with %s\n%s\n", out, err)
 		}
+		fmt.Println(strings.TrimSpace(string(out[:])))
 
 	case "gcp":
 		serviceaccount := []byte(secret.Data["serviceaccount.json"])
@@ -140,6 +142,7 @@ func operate(provider, arguments string) string {
 
 		arguments := arguments + " --account=" + account + " --project=" + project
 		args := strings.Fields(arguments)
+		args = args[1:]
 		cmd := exec.Command("gcloud", args...)
 		out, err = cmd.CombinedOutput()
 		if err != nil {
@@ -150,6 +153,7 @@ func operate(provider, arguments string) string {
 		if err != nil {
 			os.Exit(2)
 		}
+		fmt.Println(strings.TrimSpace(string(out[:])))
 	case "az":
 		clientID := []byte(secret.Data["clientID"])
 		clientSecret := []byte(secret.Data["clientSecret"])
@@ -163,11 +167,13 @@ func operate(provider, arguments string) string {
 
 		arguments := arguments + " --subscription " + string(subscriptionID[:])
 		args := strings.Fields(arguments)
+		args = args[1:]
 		cmd := exec.Command("az", args...)
 		out, err = cmd.CombinedOutput()
 		if err != nil {
 			log.Fatalf("az CLI failed with %s\n%s\n", out, err)
 		}
+		fmt.Println(strings.TrimSpace(string(out[:])))
 
 	case "openstack":
 		authURL := ""


### PR DESCRIPTION
**What this PR does / why we need it**:
gardenctl is unable to operate against gcp/aws/azure
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/389

**Special notes for your reviewer**:

**Release note**:
```improvement operator
fix issue gardenctl unable to operate against gcp/aws/azure in v0.22.0
```
