### PR TITLE
remove release msg from #sap-tech-gardener slack channel

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -38,8 +38,6 @@ gardenctl:
           release_callback: './.ci/update_latest_version'
         slack:
           channel_cfgs:
-          - channel_name: 'C9CEBQPGE' #sap-tech-gardener
-            slack_cfg_name: 'ti_workspace'
           - channel_name: 'C01BKP30K1U' #sap-tech-gardenctl
             slack_cfg_name: 'ti_workspace'
         publish:


### PR DESCRIPTION
**What this PR does / why we need it**:
As now we have #sap-tech-gardenctl channel for sending release msg, per https://sap-ti.slack.com/archives/C9CEBQPGE/p1603098983232300?thread_ts=1602851620.231700&cid=C9CEBQPGE , removing release msg from #sap-tech-gardener channel
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
CC @dansible @rfranzke 
```improvement operator
removing release msg from #sap-tech-gardener channel
```
