### PR TITLE
Gactl shoot

### DIFF
--- a/.github/actions/k8s/action.yml
+++ b/.github/actions/k8s/action.yml
@@ -1,0 +1,20 @@
+name: 'Apply a k8s manifest'
+description: 'This actions will apply k8s manifest'
+inputs:
+  path-to-file:
+    description: 'The path to the manifest to apply'
+    required: true
+  shoot-name: 
+    description: 'The name of the shoot'
+    required: true  
+runs:
+  using: "composite"
+  steps: 
+    - run: kubectl apply -f ${{ inputs.path-to-file }}
+      shell: bash
+    - run: kubectl patch shoot ${{ inputs.shoot-name }} -p '{"spec":{"hibernation":{"enabled":false}}}'
+      shell: bash
+    - run: while [[ $(kubectl get shoot ${{ inputs.shoot-name }} | awk -v i=2 -v j=6 'FNR == i {print $j}') != "Awake" ]]; do echo 'Waiting for the cluster to wake up...'; sleep 5; done
+      shell: bash
+    - run: echo Completed!
+      shell: bash

--- a/.github/gardener_clusters/gctl-aws.yaml
+++ b/.github/gardener_clusters/gctl-aws.yaml
@@ -1,0 +1,91 @@
+kind: Shoot
+apiVersion: core.gardener.cloud/v1beta1
+metadata:
+  name: gctl-aws
+  namespace: garden-gardenctl
+  labels:
+    shoot.gardener.cloud/status: healthy
+  annotations:
+    gardener.cloud/created-by: daniel.pacrami@sap.com
+  finalizers:
+    - gardener
+spec:
+  addons:
+    kubernetesDashboard:
+      enabled: false
+      authenticationMode: token
+    nginxIngress:
+      enabled: false
+      externalTrafficPolicy: Cluster
+  cloudProfileName: aws
+  dns:
+    domain: gctl-aws.gardenctl.shoot.dev.k8s-hana.ondemand.com
+  hibernation:
+    enabled: true
+    schedules:
+      - start: '00 17 * * 1,2,3,4,5'
+        location: America/New_York
+  kubernetes:
+    allowPrivilegedContainers: true
+    kubeAPIServer:
+      enableBasicAuthentication: false
+    kubeControllerManager:
+      nodeCIDRMaskSize: 24
+    kubeProxy:
+      mode: IPTables
+    kubelet:
+      failSwapOn: true
+      kubeReserved:
+        cpu: 80m
+        memory: 1Gi
+    version: 1.19.1
+  networking:
+    type: calico
+    pods: 100.96.0.0/11
+    nodes: 10.250.0.0/16
+    services: 100.64.0.0/13
+  maintenance:
+    autoUpdate:
+      kubernetesVersion: true
+      machineImageVersion: true
+    timeWindow:
+      begin: 060000+0000
+      end: 070000+0000
+  provider:
+    type: aws
+    controlPlaneConfig:
+      apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
+      kind: ControlPlaneConfig
+    infrastructureConfig:
+      apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
+      kind: InfrastructureConfig
+      networks:
+        vpc:
+          cidr: 10.250.0.0/16
+        zones:
+          - name: eu-west-1c
+            workers: 10.250.0.0/19
+            public: 10.250.32.0/20
+            internal: 10.250.48.0/20
+    workers:
+      - name: gctl-aws
+        machine:
+          type: t3.small
+          image:
+            name: gardenlinux
+            version: 27.1.0
+        maximum: 2
+        minimum: 1
+        maxSurge: 1
+        maxUnavailable: 0
+        volume:
+          type: gp2
+          size: 50Gi
+        zones:
+          - eu-west-1c
+        systemComponents:
+          allow: true
+  purpose: testing
+  region: eu-west-1
+  secretBindingName: aws-idefixops
+  seedName: aws

--- a/.github/gardener_clusters/gctl-az.yaml
+++ b/.github/gardener_clusters/gctl-az.yaml
@@ -1,0 +1,85 @@
+kind: Shoot
+apiVersion: core.gardener.cloud/v1beta1
+metadata:
+  name: gctl-az
+  namespace: garden-gardenctl
+  labels:
+    shoot.gardener.cloud/status: healthy
+  annotations:
+    gardener.cloud/created-by: daniel.pacrami@sap.com
+  finalizers:
+    - gardener
+spec:
+  addons:
+    kubernetesDashboard:
+      enabled: false
+      authenticationMode: token
+  cloudProfileName: az
+  dns:
+    domain: gctl-az.gardenctl.shoot.dev.k8s-hana.ondemand.com
+  hibernation:
+    enabled: false
+    schedules:
+      - start: '00 17 * * 1,2,3,4,5'
+        location: America/New_York
+  kubernetes:
+    allowPrivilegedContainers: true
+    kubeAPIServer:
+      enableBasicAuthentication: false
+    kubeControllerManager:
+      nodeCIDRMaskSize: 24
+    kubeProxy:
+      mode: IPTables
+    kubelet:
+      failSwapOn: true
+      kubeReserved:
+        cpu: 80m
+        memory: 1Gi
+    version: 1.19.1
+  networking:
+    type: calico
+    pods: 100.96.0.0/11
+    nodes: 10.250.0.0/16
+    services: 100.64.0.0/13
+  maintenance:
+    autoUpdate:
+      kubernetesVersion: true
+      machineImageVersion: true
+    timeWindow:
+      begin: 090000+0000
+      end: 100000+0000
+  provider:
+    type: azure
+    controlPlaneConfig:
+      apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+      kind: ControlPlaneConfig
+    infrastructureConfig:
+      apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+      kind: InfrastructureConfig
+      networks:
+        vnet:
+          cidr: 10.250.0.0/16
+        workers: 10.250.0.0/16
+      zoned: true
+    workers:
+      - name: gctl-az
+        machine:
+          type: Standard_A1_v2
+          image:
+            name: gardenlinux
+            version: 27.1.0
+        maximum: 2
+        minimum: 1
+        maxSurge: 1
+        maxUnavailable: 0
+        volume:
+          type: Standard_LRS
+          size: 50Gi
+        zones:
+          - '2'
+        systemComponents:
+          allow: true
+  purpose: testing
+  region: westeurope
+  secretBindingName: azure-playgroud
+  seedName: az

--- a/.github/gardener_clusters/gctl-gcp.yaml
+++ b/.github/gardener_clusters/gctl-gcp.yaml
@@ -1,0 +1,83 @@
+kind: Shoot
+apiVersion: core.gardener.cloud/v1beta1
+metadata:
+  name: gctl-gcp
+  namespace: garden-gardenctl
+  labels:
+    shoot.gardener.cloud/status: healthy
+  annotations:
+    gardener.cloud/created-by: daniel.pacrami@sap.com
+  finalizers:
+    - gardener
+spec:
+  addons:
+    kubernetesDashboard:
+      enabled: false
+      authenticationMode: token
+  cloudProfileName: gcp
+  dns:
+    domain: gctl-gcp.gardenctl.shoot.dev.k8s-hana.ondemand.com
+  hibernation:
+    enabled: true
+    schedules:
+      - start: '00 17 * * 1,2,3,4,5'
+        location: America/New_York
+  kubernetes:
+    allowPrivilegedContainers: true
+    kubeAPIServer:
+      enableBasicAuthentication: false
+    kubeControllerManager:
+      nodeCIDRMaskSize: 24
+    kubeProxy:
+      mode: IPTables
+    kubelet:
+      failSwapOn: true
+      kubeReserved:
+        cpu: 80m
+        memory: 1Gi
+    version: 1.19.1
+  networking:
+    type: calico
+    pods: 100.96.0.0/11
+    nodes: 10.250.0.0/16
+    services: 100.64.0.0/13
+  maintenance:
+    autoUpdate:
+      kubernetesVersion: true
+      machineImageVersion: true
+    timeWindow:
+      begin: 090000+0000
+      end: 100000+0000
+  provider:
+    type: gcp
+    controlPlaneConfig:
+      apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+      kind: ControlPlaneConfig
+      zone: europe-west1-d
+    infrastructureConfig:
+      apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+      kind: InfrastructureConfig
+      networks:
+        workers: 10.250.0.0/16
+    workers:
+      - name: gctl-gcp
+        machine:
+          type: n1-standard-2
+          image:
+            name: gardenlinux
+            version: 27.1.0
+        maximum: 2
+        minimum: 1
+        maxSurge: 1
+        maxUnavailable: 0
+        volume:
+          type: pd-standard
+          size: 50Gi
+        zones:
+          - europe-west1-d
+        systemComponents:
+          allow: true
+  purpose: testing
+  region: europe-west1
+  secretBindingName: gcp-idefixops
+  seedName: gcp

--- a/.github/gardener_clusters/gctl-os.yaml
+++ b/.github/gardener_clusters/gctl-os.yaml
@@ -1,0 +1,83 @@
+kind: Shoot
+apiVersion: core.gardener.cloud/v1beta1
+metadata:
+  name: gctl-os
+  namespace: garden-gardenctl
+  labels:
+    shoot.gardener.cloud/status: unhealthy
+  annotations:
+    gardener.cloud/created-by: arkadiusz.szczyrba@sap.com
+  finalizers:
+    - gardener
+spec:
+  addons:
+    kubernetesDashboard:
+      enabled: false
+      authenticationMode: token
+  cloudProfileName: converged-cloud
+  dns:
+    domain: gctl-os.gardenctl.shoot.dev.k8s-hana.ondemand.com
+  hibernation:
+    enabled: false
+    schedules:
+      - start: '00 17 * * 1,2,3,4,5'
+        end: '00 08 * * 1,2,3,4,5'
+        location: Europe/Warsaw
+  kubernetes:
+    allowPrivilegedContainers: true
+    kubeAPIServer:
+      enableBasicAuthentication: false
+    kubeControllerManager:
+      nodeCIDRMaskSize: 24
+    kubeProxy:
+      mode: IPTables
+    kubelet:
+      failSwapOn: true
+      kubeReserved:
+        cpu: 80m
+        memory: 1Gi
+    version: 1.19.1
+  networking:
+    type: calico
+    pods: 100.96.0.0/11
+    nodes: 10.250.0.0/16
+    services: 100.64.0.0/13
+  maintenance:
+    autoUpdate:
+      kubernetesVersion: true
+      machineImageVersion: true
+    timeWindow:
+      begin: 220000+0000
+      end: 230000+0000
+  provider:
+    type: openstack
+    controlPlaneConfig:
+      apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
+      kind: ControlPlaneConfig
+      loadBalancerProvider: f5networks
+      zone: eu-nl-1a
+    infrastructureConfig:
+      apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
+      kind: InfrastructureConfig
+      networks:
+        workers: 10.250.0.0/16
+      floatingPoolName: FloatingIP-external-monsoon3-01
+    workers:
+      - name: worker-lx07a
+        machine:
+          type: m1.smallhdd
+          image:
+            name: gardenlinux
+            version: 27.1.0
+        maximum: 2
+        minimum: 1
+        maxSurge: 1
+        maxUnavailable: 0
+        zones:
+          - eu-nl-1a
+        systemComponents:
+          allow: true
+  purpose: testing
+  region: eu-nl-1
+  secretBindingName: gardenctl-tests-cluster
+  seedName: ccee-m3

--- a/.github/workflows/deploy-gardener-cluster.yml
+++ b/.github/workflows/deploy-gardener-cluster.yml
@@ -1,0 +1,74 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Deploy gardener cluster
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master, git-action ]
+    paths:
+      - '.github/gardener_clusters/gctl-aws.yaml'
+      - '.github/gardener_clusters/gctl-az.yaml'
+      - '.github/gardener_clusters/gctl-gcp.yaml'
+      - '.github/gardener_clusters/gctl-os.yaml'
+      - '.github/workflows/deploy-gardener-cluster.yml'
+      - '.github/actions/k8s/action.yml'
+jobs:
+  deploy_gactl_on_aws:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: azure/k8s-set-context@v1
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.GARDENER_KUBECONFIG }}       
+      - name: Execute Playbook Action Step
+        uses: gardener/gardenctl/.github/actions/k8s@master
+        with:
+          path-to-file: ".github/gardener_clusters/gctl-aws.yaml"
+          shoot-name: "gctl-aws"
+  deploy_gactl_on_az:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: azure/k8s-set-context@v1
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.GARDENER_KUBECONFIG }}       
+      - name: Execute Playbook Action Step
+        uses: gardener/gardenctl/.github/actions/k8s@master
+        with:
+          path-to-file: ".github/gardener_clusters/gctl-az.yaml"
+          shoot-name: "gctl-az"
+  deploy_gactl_on_gcp:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: azure/k8s-set-context@v1
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.GARDENER_KUBECONFIG }}       
+      - name: Execute Playbook Action Step
+        uses: gardener/gardenctl/.github/actions/k8s@master
+        with:
+          path-to-file: ".github/gardener_clusters/gctl-gcp.yaml"
+          shoot-name: "gctl-gcp"
+  deploy_gactl_on_os:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: azure/k8s-set-context@v1
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.GARDENER_KUBECONFIG }}       
+      - name: Execute Playbook Action Step
+        uses: gardener/gardenctl/.github/actions/k8s@master
+        with:
+          path-to-file: ".github/gardener_clusters/gctl-os.yaml"
+          shoot-name: "gctl-os"          
+          


### PR DESCRIPTION
**What this PR does / why we need it**:
 This feature adds a GitHub action pipeline that deploy gardener shoot manifest, so we will be able to make ssh test and more.

**What this PR does / why we need it**:
This allows us to test `gardenctl ssh` feature and might be helpful for future test to.

Which issue(s) this PR fixes:
-

**Special notes for your reviewer**:
The pipeline will wait until the clusters are awake to succeed.

**Release note**:
``
 This feature adds a GitHub action pipeline that deploy gardener shoot manifest, so we will be able to make `gardenctl ssh` test and more.
``
