### PR TITLE
inspect and refactor ls.go

### DIFF
--- a/pkg/cmd/ls.go
+++ b/pkg/cmd/ls.go
@@ -15,15 +15,14 @@
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -44,9 +43,9 @@ func NewLsCmd(targetReader TargetReader, configReader ConfigReader, ioStreams IO
 			}
 			switch args[0] {
 			case "projects":
-				return printProjectsWithShoots(target, ioStreams)
+				return printProjectsWithShoots(target, ioStreams.Out, outputFormat)
 			case "gardens":
-				PrintGardenClusters(configReader, outputFormat, ioStreams)
+				return PrintGardenClusters(configReader, ioStreams.Out, outputFormat)
 			case "seeds":
 				clientset, err := target.GardenerClient()
 				checkError(err)
@@ -57,29 +56,21 @@ func NewLsCmd(targetReader TargetReader, configReader ConfigReader, ioStreams IO
 					sm.Seed = seed.Name
 					seeds.Seeds = append(seeds.Seeds, sm)
 				}
-				if outputFormat == "yaml" {
-					y, err := yaml.Marshal(seeds)
-					checkError(err)
-					os.Stdout.Write(y)
-				} else if outputFormat == "json" {
-					j, err := json.MarshalIndent(seeds, "", "  ")
-					checkError(err)
-					fmt.Fprint(ioStreams.Out, string(j))
-				}
+				return PrintoutObject(seeds, ioStreams.Out, outputFormat)
 			case "shoots":
 				if len(target.Stack()) == 1 {
-					return printProjectsWithShoots(target, ioStreams)
+					return printProjectsWithShoots(target, ioStreams.Out, outputFormat)
 				} else if len(target.Stack()) == 2 && target.Stack()[1].Kind == "seed" {
-					getProjectsWithShootsForSeed(ioStreams)
+					return printProjectsWithShootsForSeed(ioStreams.Out, outputFormat)
 				} else if len(target.Stack()) == 2 && target.Stack()[1].Kind == "project" {
-					getSeedsWithShootsForProject(ioStreams)
+					return printSeedsWithShootsForProject(ioStreams.Out, outputFormat)
 				}
 			case "issues":
-				getIssues(target, ioStreams)
+				return printIssues(target, ioStreams.Out, outputFormat)
 			case "namespaces":
-				getNamespaces(ioStreams)
+				return printNamespaces(ioStreams.Out)
 			default:
-				return errors.New("command must be in the format: ls [gardens|projects|seeds|shoots|issues|namespaces]")
+				return errors.New("command must be in the format: " + cmd.Use)
 			}
 
 			return nil
@@ -91,7 +82,7 @@ func NewLsCmd(targetReader TargetReader, configReader ConfigReader, ioStreams IO
 }
 
 // printProjectsWithShoots lists list of projects with shoots
-func printProjectsWithShoots(target TargetInterface, ioStreams IOStreams) error {
+func printProjectsWithShoots(target TargetInterface, writer io.Writer, outFormat string) error {
 	gardenClientset, err := target.GardenerClient()
 	if err != nil {
 		return err
@@ -121,25 +112,11 @@ func printProjectsWithShoots(target TargetInterface, ioStreams IOStreams) error 
 		projects.Projects = append(projects.Projects, pm)
 	}
 
-	if outputFormat == "yaml" {
-		y, err := yaml.Marshal(projects)
-		if err != nil {
-			return err
-		}
-		os.Stdout.Write(y)
-	} else if outputFormat == "json" {
-		j, err := json.MarshalIndent(projects, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Fprint(ioStreams.Out, string(j))
-	}
-
-	return nil
+	return PrintoutObject(projects, writer, outFormat)
 }
 
 // PrintGardenClusters prints all Garden cluster in the Garden config
-func PrintGardenClusters(reader ConfigReader, outFormat string, ioStreams IOStreams) {
+func PrintGardenClusters(reader ConfigReader, writer io.Writer, outFormat string) error {
 	config := reader.ReadConfig(pathGardenConfig)
 
 	var gardens GardenClusters
@@ -148,15 +125,7 @@ func PrintGardenClusters(reader ConfigReader, outFormat string, ioStreams IOStre
 		gm.Name = garden.Name
 		gardens.GardenClusters = append(gardens.GardenClusters, gm)
 	}
-	if outFormat == "yaml" {
-		y, err := yaml.Marshal(gardens)
-		checkError(err)
-		fmt.Fprint(ioStreams.Out, string(y))
-	} else if outFormat == "json" {
-		j, err := json.MarshalIndent(gardens, "", "  ")
-		checkError(err)
-		fmt.Fprint(ioStreams.Out, string(j))
-	}
+	return PrintoutObject(gardens, writer, outFormat)
 }
 
 // getSeeds returns list of seeds
@@ -166,8 +135,8 @@ func getSeeds(clientset gardencoreclientset.Interface) *gardencorev1beta1.SeedLi
 	return seedList
 }
 
-// getProjectsWithShootsForSeed
-func getProjectsWithShootsForSeed(ioStreams IOStreams) {
+// printProjectsWithShootsForSeed
+func printProjectsWithShootsForSeed(writer io.Writer, outFormat string) error {
 	var target Target
 	ReadTarget(pathTarget, &target)
 	var projects Projects
@@ -197,19 +166,11 @@ func getProjectsWithShootsForSeed(ioStreams IOStreams) {
 		fmt.Printf("No shoots for %s\n", target.Target[1].Name)
 		os.Exit(2)
 	}
-	if outputFormat == "yaml" {
-		y, err := yaml.Marshal(projects)
-		checkError(err)
-		os.Stdout.Write(y)
-	} else if outputFormat == "json" {
-		j, err := json.MarshalIndent(projects, "", "  ")
-		checkError(err)
-		fmt.Fprint(ioStreams.Out, string(j))
-	}
+	return PrintoutObject(projects, writer, outFormat)
 }
 
-// getIssues lists broken shoot clusters
-func getIssues(target TargetInterface, ioStreams IOStreams) {
+// printIssues lists broken shoot clusters
+func printIssues(target TargetInterface, writer io.Writer, outFormat string) error {
 	gardenClientset, err := target.GardenerClient()
 	checkError(err)
 	shootList, err := gardenClientset.CoreV1beta1().Shoots("").List(metav1.ListOptions{})
@@ -280,19 +241,11 @@ func getIssues(target TargetInterface, ioStreams IOStreams) {
 			issues.Issues = append(issues.Issues, im)
 		}
 	}
-	if outputFormat == "yaml" {
-		y, err := yaml.Marshal(issues)
-		checkError(err)
-		os.Stdout.Write(y)
-	} else if outputFormat == "json" {
-		j, err := json.MarshalIndent(issues, "", "  ")
-		checkError(err)
-		fmt.Fprint(ioStreams.Out, string(j))
-	}
+	return PrintoutObject(issues, writer, outFormat)
 }
 
-// getSeedsWithShootsForProject
-func getSeedsWithShootsForProject(ioStreams IOStreams) {
+// printSeedsWithShootsForProject
+func printSeedsWithShootsForProject(writer io.Writer, outFormat string) error {
 	var target Target
 	ReadTarget(pathTarget, &target)
 
@@ -334,25 +287,18 @@ func getSeedsWithShootsForProject(ioStreams IOStreams) {
 		fmt.Printf("Project %s is empty\n", target.Target[1].Name)
 		os.Exit(2)
 	}
-	if outputFormat == "yaml" {
-		y, err := yaml.Marshal(seedsFiltered)
-		checkError(err)
-		os.Stdout.Write(y)
-	} else if outputFormat == "json" {
-		j, err := json.MarshalIndent(seedsFiltered, "", "  ")
-		checkError(err)
-		fmt.Fprint(ioStreams.Out, string(j))
-	}
+	return PrintoutObject(seedsFiltered, writer, outFormat)
 }
 
-//getNamespaces get all namespaces based on current kubeconfig
-func getNamespaces(ioStreams IOStreams) {
+//printNamespaces get all namespaces based on current kubeconfig
+func printNamespaces(writer io.Writer) error {
 	currentConfig := getKubeConfigOfCurrentTarget()
 	out, err := ExecCmdReturnOutput("kubectl", "--kubeconfig="+currentConfig, "get", "ns")
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
-	fmt.Println(string(out))
+	fmt.Fprint(writer, out)
+	return nil
 }
 
 // getProjectForNamespace returns name of project for a shoot

--- a/pkg/cmd/ls.go
+++ b/pkg/cmd/ls.go
@@ -69,11 +69,9 @@ func NewLsCmd(targetReader TargetReader, configReader ConfigReader, ioStreams IO
 				return printIssues(target, ioStreams.Out, outputFormat)
 			case "namespaces":
 				return printNamespaces(ioStreams.Out)
-			default:
-				return errors.New("command must be in the format: " + cmd.Use)
 			}
 
-			return nil
+			return errors.New("command must be in the format: " + cmd.Use)
 		},
 		ValidArgs: []string{"issues", "projects", "gardens", "seeds", "shoots", "namespaces"},
 	}

--- a/pkg/cmd/ls_test.go
+++ b/pkg/cmd/ls_test.go
@@ -103,7 +103,8 @@ var _ = Describe("Ls command", func() {
 			configReader.EXPECT().ReadConfig(gomock.Any()).Return(gardenConfig)
 
 			ioStreams, _, out, _ := cmd.NewTestIOStreams()
-			cmd.PrintGardenClusters(configReader, "yaml", ioStreams)
+			err := cmd.PrintGardenClusters(configReader, ioStreams.Out, "yaml")
+			Expect(err).To(BeNil())
 			Expect(out.String()).To(Equal("gardenClusters:\n- name: prod-1\n- name: prod-2\n"))
 		})
 	})

--- a/pkg/cmd/operate.go
+++ b/pkg/cmd/operate.go
@@ -108,7 +108,7 @@ func operate(provider, arguments string) string {
 		checkError(err)
 		err = tmpFile.Close()
 		checkError(err)
-		tmpAccount, err = ExecCmdReturnOutput("bash", "-c", "gcloud config list account --format json")
+		tmpAccount, err = ExecCmdReturnOutput("gcloud", "config", "list", "account", "--format", "json")
 		if err != nil {
 			fmt.Println("Cmd was unsuccessful")
 			os.Exit(2)

--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -810,8 +810,7 @@ func getGardenKubeConfigViaGardenName(name string) (pathToGardenKubeConfig strin
 func gardenWrapper(targetReader TargetReader, targetWriter TargetWriter, configReader ConfigReader, ioStreams IOStreams, args []string) error {
 	if len(args) == 1 {
 		// Print Garden clusters
-		PrintGardenClusters(configReader, "yaml", ioStreams)
-		return nil
+		return PrintGardenClusters(configReader, ioStreams.Out, "yaml")
 	} else if len(args) > 2 {
 		return errors.New("command must be in the format: target garden NAME")
 	}

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -15,7 +15,10 @@
 package cmd
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -271,4 +274,24 @@ func CheckToolInstalled(cliName string) bool {
 		return false
 	}
 	return true
+}
+
+//PrintoutObject print object in yaml or json format. Pass os.Stdout if desired
+func PrintoutObject(objectToPrint interface{}, writer io.Writer, outputFormat string) error {
+	if outputFormat == "yaml" {
+		yaml, err := yaml.Marshal(objectToPrint)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(writer, string(yaml))
+	} else if outputFormat == "json" {
+		json, err := json.MarshalIndent(objectToPrint, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(writer, string(json))
+	} else {
+		return errors.New("output format not supported: '" + outputFormat + "'")
+	}
+	return nil
 }

--- a/pkg/cmd/utils_test.go
+++ b/pkg/cmd/utils_test.go
@@ -15,12 +15,13 @@
 package cmd_test
 
 import (
+	"bytes"
 	"fmt"
-	"os"
-	"strings"
-
 	. "github.com/gardener/gardenctl/pkg/cmd"
 	yaml "gopkg.in/yaml.v2"
+	"os"
+	"strings"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -138,3 +139,74 @@ var _ = Describe("Utils", func() {
 		})
 	})
 })
+
+func TestPrintoutObject(t *testing.T) {
+	type netstedTestStruct struct {
+		Field2 string
+	}
+	type testStruct struct {
+		Field0 string
+		Field1 netstedTestStruct
+	}
+
+	sample1 := testStruct{
+		Field0: "value0",
+		Field1: netstedTestStruct{
+			Field2: "value2",
+		},
+	}
+
+	type args struct {
+		objectToPrint interface{}
+		outputFormat  string
+	}
+
+	tests := []struct {
+		name       string
+		args       args
+		wantWriter string
+		wantErr    bool
+	}{
+		{
+			name: "yaml output format",
+			args: args{
+				objectToPrint: sample1,
+				outputFormat:  "yaml",
+			},
+			wantWriter: "field0: value0\nfield1:\n  field2: value2\n",
+			wantErr:    false,
+		},
+		{
+			name: "json output format",
+			args: args{
+				objectToPrint: sample1,
+				outputFormat:  "json",
+			},
+			wantWriter: "{\n  \"Field0\": \"value0\",\n  \"Field1\": {\n    \"Field2\": \"value2\"\n  }\n}",
+			wantErr:    false,
+		},
+		{
+			name: "unknown output format",
+			args: args{
+				objectToPrint: sample1,
+				outputFormat:  "veryNewFormat",
+			},
+			wantWriter: "",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := &bytes.Buffer{}
+			err := PrintoutObject(tt.args.objectToPrint, writer, tt.args.outputFormat)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PrintoutObject() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotWriter := writer.String(); gotWriter != tt.wantWriter {
+				t.Errorf("PrintoutObject() gotWriter = %q, want %q", gotWriter, tt.wantWriter)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
code cleanup
**Which issue(s) this PR fixes**:
Fixes #328 

**Special notes for your reviewer**:
ls.go only inspected with this PR. No additional sanitization is required. All changes should be served as refactoring.

**Release note**:
```improvement operator
new tested method `cmd.PrintoutObject` can be used to print structures in YAML or JSON format to passed io.Writer
```
