### PR TITLE
Do not use deprecated project name label

### DIFF
--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -37,7 +37,7 @@ import (
 )
 
 // ProjectName is they key of a label on namespaces whose value holds the project name.
-const ProjectName = "project.garden.sapcloud.io/name"
+const ProjectName = "project.gardener.cloud/name"
 
 var (
 	pgarden       string


### PR DESCRIPTION
**What this PR does / why we need it**:
`project.garden.sapcloud.io/name` is deprecated with gardener/gardener#1833 and will be removed in a future release of gardener/gardener.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
gardenctl no longer relies on the deprecated `project.garden.sapcloud.io/name` label
```
