### PR TITLE
allow pass args to ssh openstack node

### DIFF
--- a/pkg/cmd/ssh_openstack.go
+++ b/pkg/cmd/ssh_openstack.go
@@ -80,6 +80,9 @@ func sshToOpenstackNode(nodeName, path, user, pathSSKeypair string, sshPublicKey
 		args = append([]string{"-vvv"}, args...)
 	}
 
+	command := os.Args[3:]
+	args = append(args, command...)
+
 	cmd := exec.Command("ssh", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
**What this PR does / why we need it**:
allow pass args to ssh openstack node
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/417

**Special notes for your reviewer**:
tested with `gardenctl ssh openstack_node exit` and `gardenctl ssh openstack_node echo true`

![image](https://user-images.githubusercontent.com/42594392/97938822-6aa2a300-1dbd-11eb-8ba3-68732510e66f.png)
![image](https://user-images.githubusercontent.com/42594392/97938831-6e362a00-1dbd-11eb-9b23-b891914f1ed0.png)


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
allow pass args to ssh openstack node
```
