### PR TITLE
remove double dash when using gardenctl aws/gcloud/az/openstack/kubectl

### DIFF
--- a/pkg/cmd/aws.go
+++ b/pkg/cmd/aws.go
@@ -26,8 +26,9 @@ import (
 // NewAwsCmd returns a new aws command.
 func NewAwsCmd(targetReader TargetReader) *cobra.Command {
 	return &cobra.Command{
-		Use:          "aws <args>",
-		SilenceUsage: true,
+		Use:                "aws <args>",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		SilenceUsage:       true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := targetReader.ReadTarget(pathTarget)
 			if !CheckShootIsTargeted(target) {
@@ -37,7 +38,8 @@ func NewAwsCmd(targetReader TargetReader) *cobra.Command {
 				fmt.Println("Please go to https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html for how to install aws cli")
 				os.Exit(2)
 			}
-			arguments := strings.Join(args[:], " ")
+
+			arguments := strings.Join(os.Args[2:], " ")
 			fmt.Println(operate("aws", arguments))
 
 			return nil

--- a/pkg/cmd/az.go
+++ b/pkg/cmd/az.go
@@ -26,8 +26,9 @@ import (
 // NewAzCmd returns a new az command.
 func NewAzCmd(targetReader TargetReader) *cobra.Command {
 	return &cobra.Command{
-		Use:          "az <args>",
-		SilenceUsage: true,
+		Use:                "az <args>",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		SilenceUsage:       true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := targetReader.ReadTarget(pathTarget)
 			if !CheckShootIsTargeted(target) {
@@ -37,7 +38,8 @@ func NewAzCmd(targetReader TargetReader) *cobra.Command {
 				fmt.Println("Please go to https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest for how to install az cli")
 				os.Exit(2)
 			}
-			arguments := strings.Join(args[:], " ")
+
+			arguments := strings.Join(os.Args[2:], " ")
 			fmt.Println(operate("az", arguments))
 
 			return nil

--- a/pkg/cmd/gcloud.go
+++ b/pkg/cmd/gcloud.go
@@ -26,8 +26,9 @@ import (
 // NewGcloudCmd return a new gcloud command.
 func NewGcloudCmd(targetReader TargetReader) *cobra.Command {
 	return &cobra.Command{
-		Use:          "gcloud <args>",
-		SilenceUsage: true,
+		Use:                "gcloud <args>",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		SilenceUsage:       true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := targetReader.ReadTarget(pathTarget)
 			if !CheckShootIsTargeted(target) {
@@ -38,7 +39,7 @@ func NewGcloudCmd(targetReader TargetReader) *cobra.Command {
 				os.Exit(2)
 			}
 
-			arguments := strings.Join(args[:], " ")
+			arguments := strings.Join(os.Args[2:], " ")
 			fmt.Println(operate("gcp", arguments))
 
 			return nil

--- a/pkg/cmd/kubectl.go
+++ b/pkg/cmd/kubectl.go
@@ -26,11 +26,12 @@ import (
 // NewKubectlCmd returns a new kubectl command.
 func NewKubectlCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "kubectl <args>",
-		Aliases: []string{"k"},
-		Short:   "",
+		Use:                "kubectl <args>",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		Aliases:            []string{"k"},
+		Short:              "",
 		Run: func(cmd *cobra.Command, args []string) {
-			arguments := "kubectl " + strings.Join(args[:], " ")
+			arguments := "kubectl " + strings.Join(os.Args[2:], " ")
 			kube(arguments)
 		},
 	}
@@ -39,10 +40,11 @@ func NewKubectlCmd() *cobra.Command {
 // NewKaCmd returns a new 'kubectl --all-namespaces' command.
 func NewKaCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "ka",
-		Hidden: true,
+		Use:                "ka",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		Hidden:             true,
 		Run: func(cmd *cobra.Command, args []string) {
-			arguments := "kubectl " + strings.Join(args[:], " ") + " --all-namespaces=true"
+			arguments := "kubectl " + strings.Join(os.Args[2:], " ") + " --all-namespaces=true"
 			kube(arguments)
 		},
 	}
@@ -51,10 +53,11 @@ func NewKaCmd() *cobra.Command {
 // NewKsCmd returns a new 'kubectl --namespace=kube-system' command.
 func NewKsCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "ks",
-		Hidden: true,
+		Use:                "ks",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		Hidden:             true,
 		Run: func(cmd *cobra.Command, args []string) {
-			arguments := "kubectl " + strings.Join(args[:], " ") + " --namespace=kube-system"
+			arguments := "kubectl " + strings.Join(os.Args[2:], " ") + " --namespace=kube-system"
 			kube(arguments)
 		},
 	}
@@ -63,10 +66,11 @@ func NewKsCmd() *cobra.Command {
 // NewKgCmd returns a new 'kubectl --namespace=garden' command.
 func NewKgCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "kg",
-		Hidden: true,
+		Use:                "kg",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		Hidden:             true,
 		Run: func(cmd *cobra.Command, args []string) {
-			arguments := "kubectl " + strings.Join(args[:], " ") + " --namespace=garden"
+			arguments := "kubectl " + strings.Join(os.Args[2:], " ") + " --namespace=garden"
 			kube(arguments)
 		},
 	}
@@ -75,10 +79,11 @@ func NewKgCmd() *cobra.Command {
 // NewKnCmd returns a new 'kubectl --namespace=<arg>' command.
 func NewKnCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "kn",
-		Hidden: true,
+		Use:                "kn",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		Hidden:             true,
 		Run: func(cmd *cobra.Command, args []string) {
-			arguments := "kubectl --namespace=" + strings.Join(args[:], " ")
+			arguments := "kubectl --namespace=" + strings.Join(os.Args[2:], " ")
 			kube(arguments)
 		},
 	}

--- a/pkg/cmd/openstack.go
+++ b/pkg/cmd/openstack.go
@@ -26,8 +26,9 @@ import (
 // NewOpenstackCmd returns a new openstack cmd.
 func NewOpenstackCmd(targetReader TargetReader) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "openstack <args>",
-		SilenceUsage: true,
+		Use:                "openstack <args>",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		SilenceUsage:       true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := targetReader.ReadTarget(pathTarget)
 			if !CheckShootIsTargeted(target) {
@@ -37,7 +38,7 @@ func NewOpenstackCmd(targetReader TargetReader) *cobra.Command {
 				fmt.Println("Please go to https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html for how to install openstack cli")
 				os.Exit(2)
 			}
-			arguments := strings.Join(args[:], " ")
+			arguments := strings.Join(os.Args[2:], " ")
 			fmt.Println(operate("openstack", arguments))
 
 			return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

remove double dash when using gardenctl aws/gcloud/az/openstack/kubectl


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/427

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
remove double dash when using gardenctl aws/gcloud/az/openstack/kubectl

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
remove double dash when using gardenctl aws/gcloud/az/openstack/kubectl
```
