### PR TITLE
Fix github action pipeline 

### DIFF
--- a/.github/actions/k8s/action.yml
+++ b/.github/actions/k8s/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
     - run: kubectl patch shoot ${{ inputs.shoot-name }} -p '{"spec":{"hibernation":{"enabled":false}}}'
       shell: bash
-    - run: while [[ $(kubectl get shoot ${{ inputs.shoot-name }} | awk -v i=2 -v j=6 'FNR == i {print $j}') != "Awake" ]]; do echo 'Waiting for the cluster to wake up...'; sleep 5; done
+    - run: while [[ $(kubectl get shoot ${{ inputs.shoot-name }} | awk -v i=2 -v j=6 'FNR == i {print $j}') != "Awake" ]]; do echo 'Waiting for the cluster to wake up...'; sleep 15; done
       shell: bash
     - run: echo Completed!
       shell: bash

--- a/.github/gardener_clusters/gctl-aws.yaml
+++ b/.github/gardener_clusters/gctl-aws.yaml
@@ -38,7 +38,7 @@ spec:
       kubeReserved:
         cpu: 80m
         memory: 1Gi
-    version: 1.19.1
+    version: 1.19.2
   networking:
     type: calico
     pods: 100.96.0.0/11

--- a/.github/gardener_clusters/gctl-az.yaml
+++ b/.github/gardener_clusters/gctl-az.yaml
@@ -35,7 +35,7 @@ spec:
       kubeReserved:
         cpu: 80m
         memory: 1Gi
-    version: 1.19.1
+    version: 1.19.2
   networking:
     type: calico
     pods: 100.96.0.0/11

--- a/.github/gardener_clusters/gctl-gcp.yaml
+++ b/.github/gardener_clusters/gctl-gcp.yaml
@@ -35,7 +35,7 @@ spec:
       kubeReserved:
         cpu: 80m
         memory: 1Gi
-    version: 1.19.1
+    version: 1.19.2
   networking:
     type: calico
     pods: 100.96.0.0/11

--- a/.github/gardener_clusters/gctl-os.yaml
+++ b/.github/gardener_clusters/gctl-os.yaml
@@ -36,7 +36,7 @@ spec:
       kubeReserved:
         cpu: 80m
         memory: 1Gi
-    version: 1.19.1
+    version: 1.19.2
   networking:
     type: calico
     pods: 100.96.0.0/11

--- a/.github/workflows/deploy-gardener-cluster.yml
+++ b/.github/workflows/deploy-gardener-cluster.yml
@@ -6,7 +6,7 @@ name: Deploy gardener cluster
 # events but only for the master branch
 on:
   push:
-    branches: [ master, git-action ]
+    branches: [ gactl-cluster ]
     paths:
       - '.github/gardener_clusters/gctl-aws.yaml'
       - '.github/gardener_clusters/gctl-az.yaml'


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixed  the error on the `Deploy gardener cluster` pipeline execution and minor change to the execution..
 
**Which issue(s) this PR fixes**:
Fixes #429 

**Release note**:
```improvement operator
A fix to the Deploy gardener cluster` pipeline and add minor change to the execution.
```
