### PR TITLE
Make logPodSeed use the current context

### DIFF
--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -140,7 +140,11 @@ func runCommand(args []string) {
 	case "addon-manager":
 		logsAddonManager()
 	case "vpn-seed":
-		logsVpnSeed(args[1])
+		if len(args) == 2 {
+			logsVpnSeed(args[1])
+		} else {
+			logsVpnSeed(emptyString)
+		}
 	case "vpn-shoot":
 		logsVpnShoot()
 	case "machine-controller-manager":
@@ -473,7 +477,6 @@ func logPodShoot(toMatch, namespace string, container string) {
 	Client, err = clientToTarget(TargetKindShoot)
 	checkError(err)
 	if container != emptyString {
-		container = " -c " + container
 		showLogsFromKubectl(namespace, toMatch, container)
 	} else {
 		showLogsFromKubectl(namespace, toMatch, emptyString)
@@ -573,9 +576,14 @@ func saveLogsControllerManager() {
 }
 
 // logsVpnSeed prints the logfile of the vpn-seed container
-func logsVpnSeed(shootName string) {
+func logsVpnSeed(shootTechnicalID string) {
 	fmt.Println("-----------------------Kube-Apiserver")
-	logPodSeed("kube-apiserver", shootName, "vpn-seed")
+	if shootTechnicalID == emptyString {
+		shootTechnicalID = getFromTargetInfo("shootTechnicalID")
+		logPodSeed("kube-apiserver", shootTechnicalID, "vpn-seed")
+	} else {
+		logPodSeed("kube-apiserver", shootTechnicalID, "vpn-seed")
+	}
 }
 
 // logsEtcdOpertor prints the logfile of the etcd-operator


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove useless flag on the `logPodShoot` function
- Allow the `gardenctl logs vpn-seed` to use the current context 

**Which issue(s) this PR fixes**:
Fixes #388 

**Special notes for your reviewer**:
- none

**Release note**:
```improvement operator
- Remove useless flag on the `logPodShoot` function
- Allow the `gardenctl logs vpn-seed` to use the current context 
```
