### PR TITLE
Validate GARDENCONFIG path set explicitly before usage

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -104,9 +105,12 @@ func Execute() {
 	CreateFileIfNotExists(pathTarget, 0644)
 	gardenConfig = os.Getenv("GARDENCONFIG")
 	if gardenConfig != "" {
+		if _, err := os.Stat(gardenConfig); err != nil {
+			fmt.Println("gardenctl configuration set in environment does not exist")
+			os.Exit(1)
+		}
 		pathGardenConfig = gardenConfig
-	}
-	if _, err := os.Stat(pathGardenConfig); err != nil {
+	} else if _, err := os.Stat(pathGardenConfig); err != nil {
 		CreateFileIfNotExists(pathGardenConfig, 0644)
 	}
 	GetGardenClusterKubeConfigFromConfig(pathGardenConfig, pathTarget)


### PR DESCRIPTION
**What this PR does / why we need it**:
While setting up a local development environment for gardenctl I set GARDENCONFIG to a wrong path by mistake. After that `Please provide a gardenctl configuration before usage` was printed on the command line. That was weird because I set an environment variable as given at the README.md. After realizing my mistake I further wondered why a `gardenerconfig.yaml` was present at the directory in question.

gardenctl should present an more helpful error message when the environment variable GARDENCONFIG is set explicitly before usage.  This PR adds a check to remove the inconsistent behavior.

**Special notes for your reviewer**:

- Set GARDENCONFIG to an invalid path like `GARDENCONFIG=/tmp/nothing/exists/here` and execute. Normally it would output `open /tmp/nothing/exists/here: no such file or directory` which is fine.
- Now set `GARDENCONFIG=/tmp/no-config-here.yaml` (expecting /tmp exists). This time it outputs "Please provide a gardenctl configuration before usage" but continues. Furthermore the yaml file is created.