### PR TITLE
enable loki-0 for cluster

### DIFF
--- a/.github/gardener_clusters/gctl-gcp.yaml
+++ b/.github/gardener_clusters/gctl-gcp.yaml
@@ -77,7 +77,7 @@ spec:
           - europe-west1-d
         systemComponents:
           allow: true
-  purpose: testing
+  purpose: development
   region: europe-west1
   secretBindingName: gcp-idefixops
   seedName: gcp


### PR DESCRIPTION
purpose development is sufficient for enabling loki on cluster

**What this PR does / why we need it**:
enable loki-0 on cluster for testing 
