### PR TITLE
fix aws ssh issue

### DIFF
--- a/pkg/cmd/ssh_aws.go
+++ b/pkg/cmd/ssh_aws.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 )
 
 // AwsInstanceAttribute stores all the critical information for creating an instance on AWS.
@@ -73,7 +72,8 @@ func sshToAWSNode(targetReader TargetReader, nodeName, path, user, pathSSKeypair
 
 	a.createNodeHostSecurityGroup()
 
-	a.sshPortCheck()
+	err := CheckIPPortReachable(a.BastionIP, "22")
+	checkError(err)
 
 	bastionNode := user + "@" + a.BastionIP
 	node := user + "@" + nodeName
@@ -234,28 +234,6 @@ func (a *AwsInstanceAttribute) createBastionHostInstance() {
 	// get bastion private IP
 	arguments = "ec2 describe-instances --instance-id " + a.BastionInstanceID + " --query Reservations[*].Instances[*].PrivateIpAddress"
 	a.BastionPrivIP = strings.Trim(operate("aws", arguments), "\n")
-}
-
-// Bastion SSH port check
-func (a *AwsInstanceAttribute) sshPortCheck() {
-	// waiting 60 seconds for SSH port open
-	fmt.Println("Waiting 60 seconds for Bastion SSH port open")
-	attemptCnt := 0
-	for attemptCnt < 6 {
-		ncCmd := fmt.Sprintf("timeout 10 nc -vtnz %s 22", a.BastionIP)
-		cmd := exec.Command("bash", "-c", ncCmd)
-		output, _ := cmd.CombinedOutput()
-		fmt.Println("=>", string(output))
-		if strings.Contains(string(output), "open") {
-			fmt.Println("Opened SSH Port on Bastion")
-			return
-		}
-		time.Sleep(time.Second * 10)
-		attemptCnt++
-	}
-	fmt.Println("SSH Port Open on Bastion TimeOut")
-	a.cleanupAwsBastionHost()
-	os.Exit(0)
 }
 
 // cleanupAwsBastionHost cleans up the bastion host for the targeted cluster.

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -351,8 +351,8 @@ func PrintoutObject(objectToPrint interface{}, writer io.Writer, outputFormat st
 
 //CheckIPPortReachable check whether IP with port is reachable within 1 min
 func CheckIPPortReachable(ip string, port string) error {
-	attemptCnt := 0
-	for attemptCnt < 6 {
+	attemptCount := 0
+	for attemptCount < 6 {
 		timeout := time.Second * 10
 		conn, _ := net.DialTimeout("tcp", net.JoinHostPort(ip, port), timeout)
 		if conn != nil {
@@ -360,7 +360,7 @@ func CheckIPPortReachable(ip string, port string) error {
 			fmt.Printf("IP %s port %s is reachable\n", ip, port)
 			return nil
 		}
-		attemptCnt++
+		attemptCount++
 	}
 	return fmt.Errorf("IP %s port %s is not reachable", ip, port)
 }

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -349,7 +349,7 @@ func PrintoutObject(objectToPrint interface{}, writer io.Writer, outputFormat st
 	return nil
 }
 
-//CheckIPPortReachable check whether IP with port is reachable within 1 min
+//CheckIPPortReachable check whether IP with port is reachable within 1 min,retrigger the test
 func CheckIPPortReachable(ip string, port string) error {
 	attemptCnt := 0
 	for attemptCnt < 6 {

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -354,10 +354,7 @@ func CheckIPPortReachable(ip string, port string) error {
 	attemptCnt := 0
 	for attemptCnt < 6 {
 		timeout := time.Second * 10
-		conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, port), timeout)
-		if err != nil {
-			fmt.Println("Connecting error:", err)
-		}
+		conn, _ := net.DialTimeout("tcp", net.JoinHostPort(ip, port), timeout)
 		if conn != nil {
 			defer conn.Close()
 			fmt.Printf("IP %s port %s is reachable\n", ip, port)

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -349,7 +349,7 @@ func PrintoutObject(objectToPrint interface{}, writer io.Writer, outputFormat st
 	return nil
 }
 
-//CheckIPPortReachable check whether IP with port is reachable within 1 min,retrigger the test
+//CheckIPPortReachable check whether IP with port is reachable within 1 min
 func CheckIPPortReachable(ip string, port string) error {
 	attemptCnt := 0
 	for attemptCnt < 6 {

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -349,7 +349,7 @@ func PrintoutObject(objectToPrint interface{}, writer io.Writer, outputFormat st
 	return nil
 }
 
-//CheckIPPortReachable check whether IP with port is reachable with 2 min
+//CheckIPPortReachable check whether IP with port is reachable within 1 min
 func CheckIPPortReachable(ip string, port string) error {
 	attemptCnt := 0
 	for attemptCnt < 6 {
@@ -363,7 +363,6 @@ func CheckIPPortReachable(ip string, port string) error {
 			fmt.Printf("IP %s port %s is reachable\n", ip, port)
 			return nil
 		}
-		time.Sleep(time.Second * 10)
 		attemptCnt++
 	}
 	return fmt.Errorf("IP %s port %s is not reachable", ip, port)

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -349,17 +349,22 @@ func PrintoutObject(objectToPrint interface{}, writer io.Writer, outputFormat st
 	return nil
 }
 
-//CheckIPPortReachable check whether IP with port is reachable with 1 min
+//CheckIPPortReachable check whether IP with port is reachable with 2 min
 func CheckIPPortReachable(ip string, port string) error {
-	timeout := time.Second * 60
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, port), timeout)
-	if err != nil {
-		fmt.Println("Connecting error:", err)
-	}
-	if conn != nil {
-		defer conn.Close()
-		fmt.Printf("IP %s port %s is reachable\n", ip, port)
-		return nil
+	attemptCnt := 0
+	for attemptCnt < 6 {
+		timeout := time.Second * 10
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, port), timeout)
+		if err != nil {
+			fmt.Println("Connecting error:", err)
+		}
+		if conn != nil {
+			defer conn.Close()
+			fmt.Printf("IP %s port %s is reachable\n", ip, port)
+			return nil
+		}
+		time.Sleep(time.Second * 10)
+		attemptCnt++
 	}
 	return fmt.Errorf("IP %s port %s is not reachable", ip, port)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix aws ssh issue
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/442

**Special notes for your reviewer**:
1) in my env, `nc -vtnz ip port` returns sth like `127.0.0.1 49269 open` so the result should grep `open`, instead of `succeed`
not sure my `nc` is correct one
```
nc --version                                               (ccee-m3/default)
netcat (The GNU Netcat) 0.7.1
Copyright (C) 2002 - 2003  Giovanni Giacobbi

This program comes with NO WARRANTY, to the extent permitted by law.
You may redistribute copies of this program under the terms of
the GNU General Public License.
For more information about these matters, see the file named COPYING.

Original idea and design by Avian Research <hobbit@avian.org>,
Written by Giovanni Giacobbi <giovanni@giacobbi.net>.
```

2) fix a small typo, `shh` to `ssh`

3) when bastion exist, `a.BastionPrivIP` and `a.BastionIP` should also be assigned with values (like what they are treat in non bastion exist path) , otherwise following step will fail due to these two properties empty

**Release note**:
```improvement operator
fix aws ssh issue
```
