### PR TITLE
exit and print error message when seed.spec.SecretRef unavailable

### DIFF
--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -450,6 +450,10 @@ func targetSeed(targetReader TargetReader, targetWriter TargetWriter, name strin
 		fmt.Println("Seed not found")
 		os.Exit(2)
 	}
+	if seed.Spec.SecretRef == nil {
+		fmt.Println("Spec.SecretRef is missing in this seed, seed not reachable")
+		os.Exit(2)
+	}
 	kubeSecret, err := Client.CoreV1().Secrets(seed.Spec.SecretRef.Namespace).Get(seed.Spec.SecretRef.Name, metav1.GetOptions{})
 	checkError(err)
 	pathSeed := filepath.Join(pathGardenHome, "cache", gardenName, "seeds", name)


### PR DESCRIPTION
**What this PR does / why we need it**:
exit and print error message when seed.spec.SecretRef unavailable
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/411

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
exit and print error message when seed.spec.SecretRef unavailable
```
