### PR TITLE
Issue 433 logs loki

### DIFF
--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -415,7 +415,9 @@ func BuildLokiCommandArgs(kubeconfig string, namespace, podName, container strin
 		namespace,
 		"--",
 		"wget",
-		"'http://localhost:3100/loki/api/v1/query_range'",
+		"--header",
+		"'X-Scope-OrgID: operator'",
+		"http://localhost:3100/loki/api/v1/query_range",
 		"-O-",
 	}
 
@@ -438,6 +440,8 @@ func BuildLokiCommandArgs(kubeconfig string, namespace, podName, container strin
 	command += "'"
 
 	args = append(args, command)
+	fmt.Println("")
+	fmt.Println(strings.Join(args, " "))
 	return args
 }
 

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -415,6 +415,8 @@ func BuildLogCommandArgs(kubeconfig string, namespace, podName, container string
 }
 
 //BuildLokiCommandArgs build kubect command to get logs from loki
+//https://github.com/gardener/gardener/blob/master/docs/usage/logging.md
+//Loki multi-tenant is enabled so it's required to pass 'X-Scope-OrgID' header
 func BuildLokiCommandArgs(kubeconfig string, namespace, podName, container string, tail int64, sinceSeconds time.Duration) []string {
 	args := []string{
 		"--kubeconfig=" + kubeconfig,
@@ -449,8 +451,6 @@ func BuildLokiCommandArgs(kubeconfig string, namespace, podName, container strin
 	command += fmt.Sprintf("&&start=%d&&end=%d", now-sinceNanoSec, now)
 
 	args = append(args, command)
-	fmt.Println("")
-	fmt.Println(strings.Join(args, " "))
 	return args
 }
 

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -229,7 +229,7 @@ func saveLogsAll(targetReader TargetReader) {
 	fmt.Println("All logs have been saved in " + path + "/logs/ folder")
 }
 
-func versionGreaterThanLokiRelease(version string) bool {
+func VersionGreaterThanLokiRelease(version string) bool {
 	lokiRelease, _ := semver.NewVersion("1.8.0")
 
 	ver, err := semver.NewVersion(version)
@@ -265,7 +265,7 @@ func logPod(targetReader TargetReader, toMatch string, toTarget string, containe
 	}
 
 	if flags.loki {
-		if versionGreaterThanLokiRelease(shoot.Status.Gardener.Version) {
+		if VersionGreaterThanLokiRelease(shoot.Status.Gardener.Version) {
 			showLogsFromLoki(namespace, toMatch, container)
 		} else {
 			fmt.Println("--loki flag is available only for gardener version >= 1.8.0")

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -229,6 +229,7 @@ func saveLogsAll(targetReader TargetReader) {
 	fmt.Println("All logs have been saved in " + path + "/logs/ folder")
 }
 
+//VersionGreaterThanLokiRelease checks if provided version supports Loki
 func VersionGreaterThanLokiRelease(version string) bool {
 	lokiRelease, _ := semver.NewVersion("1.8.0")
 

--- a/pkg/cmd/logs_test.go
+++ b/pkg/cmd/logs_test.go
@@ -72,8 +72,8 @@ var _ = Describe("Logs and kubecmd command", func() {
 		It("should build kubectl command", func() {
 
 			//test `normalizeTimestamp` first - replace timestamp with some predefined values
-			expected := `--kubeconfig=/path/to/configfile exec loki-0 -n myns -- wget 'http://localhost:3100/loki/api/v1/query_range' -O- --post-data='query={pod_name=~"nginx-pod.*"}&&query={container_name=~"mycontainer.*"&&limit=200&&start=1603184413805314000&&end=1604394013805314000'`
-			expectedNorm := `--kubeconfig=/path/to/configfile exec loki-0 -n myns -- wget 'http://localhost:3100/loki/api/v1/query_range' -O- --post-data='query={pod_name=~"nginx-pod.*"}&&query={container_name=~"mycontainer.*"&&limit=200&&start=101010&&end=202020'`
+			expected := `--kubeconfig=/path/to/configfile exec loki-0 -n myns -- wget --header X-Scope-OrgID: operator http://localhost:3100/loki/api/v1/query_range -O- --post-data query={pod_name=~"nginx-pod.*"}&&query={container_name=~"mycontainer.*"&&limit=200&&start=1603184413805314000&&end=1604394013805314000`
+			expectedNorm := `--kubeconfig=/path/to/configfile exec loki-0 -n myns -- wget --header X-Scope-OrgID: operator http://localhost:3100/loki/api/v1/query_range -O- --post-data query={pod_name=~"nginx-pod.*"}&&query={container_name=~"mycontainer.*"&&limit=200&&start=101010&&end=202020`
 			norm := normalizeTimestamp(expected)
 			Expect(expectedNorm).To(Equal(norm))
 
@@ -88,13 +88,13 @@ var _ = Describe("Logs and kubecmd command", func() {
 
 	Context("versions comparison", func() {
 		It("should be greater than Loki version release", func() {
-			Expect(versionGreaterThanLokiRelease("1.13.0-dev-38d42e28ec51d5b8728fcade4ae5b50f3d3eaca1")).To(BeTrue())
-			Expect(versionGreaterThanLokiRelease("1.13.0")).To(BeTrue())
+			Expect(cmd.VersionGreaterThanLokiRelease("1.13.0-dev-38d42e28ec51d5b8728fcade4ae5b50f3d3eaca1")).To(BeTrue())
+			Expect(cmd.VersionGreaterThanLokiRelease("1.13.0")).To(BeTrue())
 		})
 
 		It("should be earlier than Loki version release", func() {
-			Expect(versionGreaterThanLokiRelease("1.8.0-dev-38d42e28ec51d5b8728fcade4ae5b50f3d3eaca1")).To(BeFalse())
-			Expect(versionGreaterThanLokiRelease("1.7.0")).To(BeFalse())
+			Expect(cmd.VersionGreaterThanLokiRelease("1.8.0-dev-38d42e28ec51d5b8728fcade4ae5b50f3d3eaca1")).To(BeFalse())
+			Expect(cmd.VersionGreaterThanLokiRelease("1.7.0")).To(BeFalse())
 		})
 	})
 })

--- a/pkg/cmd/logs_test.go
+++ b/pkg/cmd/logs_test.go
@@ -17,6 +17,7 @@ package cmd_test
 import (
 	"github.com/gardener/gardenctl/pkg/cmd"
 	mockcmd "github.com/gardener/gardenctl/pkg/mock/cmd"
+	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"
 
 	"regexp"

--- a/pkg/cmd/logs_test.go
+++ b/pkg/cmd/logs_test.go
@@ -17,7 +17,6 @@ package cmd_test
 import (
 	"github.com/gardener/gardenctl/pkg/cmd"
 	mockcmd "github.com/gardener/gardenctl/pkg/mock/cmd"
-	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"
 
 	"regexp"
@@ -83,6 +82,19 @@ var _ = Describe("Logs and kubecmd command", func() {
 			command := strings.Join(args, " ")
 			normCommand := normalizeTimestamp(command)
 			Expect(expectedNorm).To(Equal(normCommand))
+			Expect(len(args)).To(Equal(13))
+		})
+	})
+
+	Context("versions comparison", func() {
+		It("should be greater than Loki version release", func() {
+			Expect(versionGreaterThanLokiRelease("1.13.0-dev-38d42e28ec51d5b8728fcade4ae5b50f3d3eaca1")).To(BeTrue())
+			Expect(versionGreaterThanLokiRelease("1.13.0")).To(BeTrue())
+		})
+
+		It("should be earlier than Loki version release", func() {
+			Expect(versionGreaterThanLokiRelease("1.8.0-dev-38d42e28ec51d5b8728fcade4ae5b50f3d3eaca1")).To(BeFalse())
+			Expect(versionGreaterThanLokiRelease("1.7.0")).To(BeFalse())
 		})
 	})
 })

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -41,6 +41,10 @@ import (
 // checkError checks if an error during execution occurred
 func checkError(err error) {
 	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			log.Println(string(exiterr.Stderr))
+		}
+
 		if debugSwitch {
 			_, fn, line, _ := runtime.Caller(1)
 			log.Fatalf("[error] %s:%d \n %v", fn, line, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes bug with fetching log using Loki
**Which issue(s) this PR fixes**:
Fixes #433 

**Special notes for your reviewer**:
target shoot cluster first and then execute:
gardenctl logs etcd-main etcd --loki

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement
fixes the bug with fetching log using Loki and also prints more meaningful error messages if subcommands exit with an error

```
