### PR TITLE
fix several gardenctl ssh aws issue

### DIFF
--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -353,10 +353,10 @@ func PrintoutObject(objectToPrint interface{}, writer io.Writer, outputFormat st
 	return nil
 }
 
-//CheckIPPortReachable check whether IP with port is reachable within 1 min
+//CheckIPPortReachable check whether IP with port is reachable within certain period of time
 func CheckIPPortReachable(ip string, port string) error {
 	attemptCount := 0
-	for attemptCount < 6 {
+	for attemptCount < 12 {
 		timeout := time.Second * 10
 		conn, _ := net.DialTimeout("tcp", net.JoinHostPort(ip, port), timeout)
 		if conn != nil {
@@ -364,6 +364,8 @@ func CheckIPPortReachable(ip string, port string) error {
 			fmt.Printf("IP %s port %s is reachable\n", ip, port)
 			return nil
 		}
+		fmt.Println("waiting for 10 seconds to retry")
+		time.Sleep(time.Second * 10)
 		attemptCount++
 	}
 	return fmt.Errorf("IP %s port %s is not reachable", ip, port)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix several gardenctl ssh aws issue:
- if we get VPC from host, there might be several VPCs but we didn't check it, hence changing to get vpc from subnet
- there might be a list of images, use the first one
- there's some issue in golang native check network function `net.DialTimeout` (at least in my testing), sometimes the `timeout` value passed doesn't take effect, the DialTimeout function will fail immediately , hence add time.Sleep to force wait 10s to retry

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/466

**Special notes for your reviewer**:

thanks for @mandelsoft @DockToFuture catching this, @dansible FYI

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
fix several gardenctl ssh aws issue:
- if we get VPC from host, there might be several VPC but we didn't check it, hence changing to get vpc from subnet
- there might be a list of images, use the first one
- there's some issue in golang native check network function `net.DialTimeout` (at least in my testing), sometimes the `timeout` value passed doesn't take effect, the DialTimeout function will fail immediately , hence add time.Sleep to force wait 10s to retry
```
