### PR TITLE
Rename categories in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,9 +12,9 @@ Fixes #
 
 Format of block header: <category> <target_group>
 Possible values:
-- category:       improvement|noteworthy|action
-- target_group:   user|operator|developer
+- category:       breaking|feature|bugfix|doc|other
+- target_group:   user|operator|developer|dependency
 -->
-```improvement operator
+```other operator
 
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt the github pull request template to the new release note categories.
For more details, see gardener/cc-utils#497, https://github.com/gardener/gardener/pull/3230

> The "old" categories are still kept for compatibility reasons, but will be removed in the future. This is how the old categories are mapped to the new ones:
> `improvement` -> `other`
> `noteworthy` -> remains as is, but the category title changes from Most notable changes to  :newspaper:  Noteworthy
> `action` -> `breaking`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```

/area dev-productivity
/kind enhancement
/priority normal