### PR TITLE
Condense commands in `gardenctl infra orphan list`

### DIFF
--- a/pkg/cmd/orphan.go
+++ b/pkg/cmd/orphan.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewInfraCmd returns a new infra command
+// NewOrphanCmd returns a new orphan command
 func NewOrphanCmd(targetReader TargetReader) *cobra.Command {
 	return &cobra.Command{
 		Use:          "orphan",

--- a/pkg/cmd/orphan_test.go
+++ b/pkg/cmd/orphan_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Infra", func() {
+var _ = Describe("Orphan", func() {
 	var rs = []string{"vpc-03cb057da4ded427f"}
 	terraformstate := `
 },

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -154,7 +154,7 @@ func init() {
 	RootCmd.AddCommand(NewKubectlCmd(), NewKaCmd(), NewKsCmd(), NewKgCmd(), NewKnCmd())
 	RootCmd.AddCommand(NewKubectxCmd())
 	RootCmd.AddCommand(NewTerraformCmd(targetReader))
-	RootCmd.AddCommand(NewInfraCmd(targetReader))
+	RootCmd.AddCommand(NewOrphanCmd(targetReader))
 	RootCmd.AddCommand(NewAliyunCmd(targetReader), NewAwsCmd(targetReader), NewAzCmd(targetReader), NewGcloudCmd(targetReader), NewOpenstackCmd(targetReader))
 	RootCmd.AddCommand(NewInfoCmd(targetReader, ioStreams))
 	RootCmd.AddCommand(NewVersionCmd(), NewUpdateCheckCmd())


### PR DESCRIPTION
**What this PR does / why we need it**:
Condense the command into a single verb gardenctl orphan (g orphan) with meaningful help message
**Which issue(s) this PR fixes**:
Fixes #475 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Condense the command into a single verb gardenctl orphan (g orphan) with meaningful help message
```
