### PR TITLE
Fix kubeconfig leak

### DIFF
--- a/pkg/cmd/kubeconfig_writer.go
+++ b/pkg/cmd/kubeconfig_writer.go
@@ -22,10 +22,9 @@ import (
 
 // Write writes kubeconfig to given path
 func (w *GardenctlKubeconfigWriter) Write(kubeconfigPath string, kubeconfig []byte) error {
-	dir, file := path.Split(kubeconfigPath)
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(path.Dir(kubeconfigPath), os.ModePerm); err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(file, kubeconfig, 0644)
+	return ioutil.WriteFile(kubeconfigPath, kubeconfig, 0644)
 }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

This PR fixes gardenctl to not leak the Seed's kubeconfig in the current working directory when executing `g get shoot`.

**Which issue(s) this PR fixes**:
Fixes #486 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bug operator
A bug has been fixed which caused `gardenctl get shoot` to write the Seed's kubeconfig to the current working directory instead of the gardenctl cache directory.
```
