### PR TITLE
Add garden show infra cmd

### DIFF
--- a/pkg/cmd/operate.go
+++ b/pkg/cmd/operate.go
@@ -204,9 +204,13 @@ func operate(provider, arguments string) string {
 		if err != nil {
 			os.Exit(2)
 		}
-		err = ExecCmd(nil, arguments, false)
+
+		args := strings.Fields(arguments)
+		cmd := exec.Command("aliyun", args...)
+		out, err = cmd.CombinedOutput()
 		if err != nil {
-			os.Exit(2)
+			fmt.Println(err)
+			log.Fatalf("Aliyun CLI failed with %s\n%s\n", out, err)
 		}
 	}
 	return (strings.TrimSpace(string(out[:])))

--- a/pkg/cmd/show_test.go
+++ b/pkg/cmd/show_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Show command", func() {
 			err := command.Execute()
 
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Command must be in the format: show (operator|gardener-dashboard|api|scheduler|controller-manager|etcd-operator|etcd-main|etcd-events|addon-manager|vpn-seed|vpn-shoot|machine-controller-manager|kubernetes-dashboard|prometheus|grafana|tf (infra|dns|ingress)|cluster-autoscaler)"))
+			Expect(err.Error()).To(Equal("Command must be in the format: show (infra|operator|gardener-dashboard|api|scheduler|controller-manager|etcd-operator|etcd-main|etcd-events|addon-manager|vpn-seed|vpn-shoot|machine-controller-manager|kubernetes-dashboard|prometheus|grafana|tf (infra|dns|ingress)|cluster-autoscaler)"))
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Add garden show infra cmd to display cloud resources associated to shoot (g show infra)
**Which issue(s) this PR fixes**:
Fixes #477 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add garden show infra cmd to display cloud resources associated to shoot (g show infra)
```
