### PR TITLE
Enable ssh a VM when it can't register as a kube node on Alicloud

### DIFF
--- a/pkg/cmd/ssh_alicloud.go
+++ b/pkg/cmd/ssh_alicloud.go
@@ -480,11 +480,17 @@ func fetchAlicloudInstanceIDByNodeName(nodeName string) (string, error) {
 	checkError(err)
 	for _, node := range nodes.Items {
 		if nodeName == node.Name {
-			return strings.Split(node.Spec.ProviderID, ".")[1], nil
+			if node.Spec.ProviderID != "" {
+				return strings.Split(node.Spec.ProviderID, ".")[1], nil
+			}
 		}
 	}
 
-	return "", fmt.Errorf("Cannot find InstanceID for node %q", nodeName)
+	//Fallback: Normally, node id is izbp1c11iq8wz8p58ve2mhz, instance id looks like: i-bp1c11iq8wz8p58ve2mh
+	instanceID := strings.TrimRight(nodeName, "z")
+	instanceID = strings.Replace(instanceID, "z", "-", 1)
+
+	return instanceID, nil
 }
 
 // checkIsThereGardenerUser checks if the bastion contains gardener user


### PR DESCRIPTION
**What this PR does / why we need it**:
We could still ssh to a VM even this VM can't join k8s cluster as a node.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
