### PR TITLE
bugfix invoking logs fails

### DIFF
--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -719,12 +719,12 @@ func logsMachineControllerManager(targetReader TargetReader) {
 	if IsControlPlaneTargeted(targetReader) {
 		logPodWhileControlPlaneTargeted(targetReader, "machine-controller-manager", "seed", emptyString)
 	} else {
-		logPod(targetReader, "machine-controller-manager", "seed", emptyString)
+		logPod(targetReader, "machine-controller-manager", "seed", "machine-controller-manager")
 	}
 }
 
 func saveLogsMachineControllerManager(targetReader TargetReader) {
-	saveLogPod(targetReader, "machine-controller-manager", "seed", emptyString)
+	saveLogPod(targetReader, "machine-controller-manager", "seed", "machine-controller-manager")
 }
 
 // logsKubernetesDashboard prints the logfile of the dashboard


### PR DESCRIPTION
**What this PR does / why we need it**:
bugfix no log return when `g logs --since=6h --loki machine-controller-manager` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
bugfix no log return when `g logs --since=6h --loki machine-controller-manager` 
```
