### PR TITLE
Ensure shell command pod names are lowercase

### DIFF
--- a/pkg/cmd/shell.go
+++ b/pkg/cmd/shell.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -138,7 +139,7 @@ func shellToNode(client kubernetes.Interface, targetKind TargetKind, nodeName st
 	if err != nil {
 		return err
 	}
-	podName = fmt.Sprintf("rootpod-%s-%s", podName, internalIP)
+	podName = fmt.Sprintf("rootpod-%s-%s", strings.ToLower(podName), internalIP)
 	if targetKind == TargetKindShoot {
 		namespace = metav1.NamespaceSystem
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures `shell` command pod names conform to the pod name requirements by making sure the output of `whoami` is lowercased.

**Which issue(s) this PR fixes**:
Fixes #514

**Special notes for your reviewer**:

**Release note**:

```other operator
Fixed a bug that caused the `shell` command to fail if the username contained an uppercase letter.
```
