### PR TITLE
Pin github actions

### DIFF
--- a/.github/workflows/conflict.yaml
+++ b/.github/workflows/conflict.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check if prs are dirty
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@b8bf8341285ec9a4567d4318ba474fee998a6919 # pin@releases/2.x
         with:
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"

--- a/.github/workflows/deploy-gardener-cluster.yml
+++ b/.github/workflows/deploy-gardener-cluster.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: azure/k8s-set-context@v1
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+      - uses: azure/k8s-set-context@2f6bfda1e23e1a8cdfcfabc5c9e8894eec34734f #pin@v1
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.GARDENER_KUBECONFIG }}       
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: azure/k8s-set-context@v1
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+      - uses: azure/k8s-set-context@2f6bfda1e23e1a8cdfcfabc5c9e8894eec34734f #pin@v1
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.GARDENER_KUBECONFIG }}       
@@ -47,8 +47,8 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: azure/k8s-set-context@v1
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+      - uses: azure/k8s-set-context@2f6bfda1e23e1a8cdfcfabc5c9e8894eec34734f #pin@v1
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.GARDENER_KUBECONFIG }}       
@@ -61,8 +61,8 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: azure/k8s-set-context@v1
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+      - uses: azure/k8s-set-context@2f6bfda1e23e1a8cdfcfabc5c9e8894eec34734f #pin@v1
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.GARDENER_KUBECONFIG }}       

--- a/.github/workflows/update-gardenctl.yml
+++ b/.github/workflows/update-gardenctl.yml
@@ -8,7 +8,7 @@ jobs:
   update_gardenctl_in_homebrew_tap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Build the binary-files
         id: build_binary_files
         run: |
@@ -17,7 +17,7 @@ jobs:
           make build
           echo ::set-output name=latest_release_filtered_tag::${GITHUB_REF##*/}
       - name: Upload binaries to release
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@ec6d3263266dc57eb6645b5f75e827987f7c217d # pin@v2.0
         with:
           files: 'bin/darwin-amd64/gardenctl-darwin-amd64;bin/linux-amd64/gardenctl-linux-amd64'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions

> **Pin actions to a full length commit SHA**
> 
> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
