### PR TITLE
Hcloud command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,18 +15,23 @@
 
 DATE=$(shell date -u +%Y-%m-%d)
 VERSION=$(shell cat VERSION | sed 's/-dev//g')
+LDFLAGS=-w
 
 .PHONY: build
 build:
 	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
 		-mod=vendor \
-		-ldflags "-w -X github.com/gardener/gardenctl/pkg/cmd.version=${VERSION} -X github.com/gardener/gardenctl/pkg/cmd.buildDate=${DATE}" \
+		-ldflags "${LDFLAGS} -X github.com/gardener/gardenctl/pkg/cmd.version=${VERSION} -X github.com/gardener/gardenctl/pkg/cmd.buildDate=${DATE}" \
 		-o bin/linux-amd64/gardenctl-linux-amd64 cmd/gardenctl/main.go
 
 	@CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 GO111MODULE=on go build \
 		-mod=vendor \
-		-ldflags "-w -X github.com/gardener/gardenctl/pkg/cmd.version=${VERSION} -X github.com/gardener/gardenctl/pkg/cmd.buildDate=${DATE}" \
+		-ldflags "${LDFLAGS} -X github.com/gardener/gardenctl/pkg/cmd.version=${VERSION} -X github.com/gardener/gardenctl/pkg/cmd.buildDate=${DATE}" \
 		-o bin/darwin-amd64/gardenctl-darwin-amd64 cmd/gardenctl/main.go
+
+.PHONY: debug-build
+debug-build: LDFLAGS=
+debug-build: build
 
 .PHONY: clean
 clean:

--- a/pkg/cmd/hcloud.go
+++ b/pkg/cmd/hcloud.go
@@ -41,7 +41,6 @@ func NewHcloudCmd(targetReader TargetReader) *cobra.Command {
 			}
 
 			arguments := strings.Join(os.Args[2:], " ")
-			fmt.Print(arguments)
 			fmt.Println(operate("hcloud", arguments))
 
 			return nil

--- a/pkg/cmd/hcloud.go
+++ b/pkg/cmd/hcloud.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// NewHcloudCmd returns a new hetzner cloud command.
+func NewHcloudCmd(targetReader TargetReader) *cobra.Command {
+	return &cobra.Command{
+		Use:                "hcloud <args>",
+		Short:              "e.g. \"gardenctl hcloud server list\"",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		SilenceUsage:       true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := targetReader.ReadTarget(pathTarget)
+			if !CheckShootIsTargeted(target) {
+				return errors.New("no shoot targeted")
+			}
+			if !CheckToolInstalled("hcloud") {
+				fmt.Println("Please go to https://github.com/hetznercloud/cli for how to install hcloud cli")
+				os.Exit(2)
+			}
+
+			arguments := strings.Join(os.Args[2:], " ")
+			fmt.Print(arguments)
+			fmt.Println(operate("hcloud", arguments))
+
+			return nil
+		},
+	}
+}

--- a/pkg/cmd/operate.go
+++ b/pkg/cmd/operate.go
@@ -212,7 +212,18 @@ func operate(provider, arguments string) string {
 			fmt.Println(err)
 			log.Fatalf("Aliyun CLI failed with %s\n%s\n", out, err)
 		}
+	case "hcloud":
+		token := []byte(secret.Data["hcloudToken"])
+		args := strings.Fields(arguments)
+		cmd := exec.Command("hcloud", args...)
+		newEnv := append(os.Environ(), "HCLOUD_TOKEN="+string(token[:]))
+		cmd.Env = newEnv
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			log.Fatalf("hcloud CLI failed with %s\n%s\n", out, err)
+		}
 	}
+
 	return (strings.TrimSpace(string(out[:])))
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -158,7 +158,8 @@ func init() {
 	RootCmd.AddCommand(NewKubectxCmd())
 	RootCmd.AddCommand(NewTerraformCmd(targetReader))
 	RootCmd.AddCommand(NewOrphanCmd(targetReader))
-	RootCmd.AddCommand(NewAliyunCmd(targetReader), NewAwsCmd(targetReader), NewAzCmd(targetReader), NewGcloudCmd(targetReader), NewOpenstackCmd(targetReader))
+	RootCmd.AddCommand(NewAliyunCmd(targetReader), NewAwsCmd(targetReader), NewAzCmd(targetReader),
+		NewGcloudCmd(targetReader), NewOpenstackCmd(targetReader), NewHcloudCmd(targetReader))
 	RootCmd.AddCommand(NewInfoCmd(targetReader, ioStreams))
 	RootCmd.AddCommand(NewVersionCmd(), NewUpdateCheckCmd())
 	RootCmd.AddCommand(NewDiagCmd(targetReader, ioStreams))


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for the [hcloud gardener extension](https://github.com/23technologies/gardener-extension-provider-hcloud).
It will extract the hetzner cloud token from the shoots environment and call the hcloud CLI with set environment variables.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Support for hcloud (hetzner cloud) cli
```
