### PR TITLE
Clean up unused var

### DIFF
--- a/pkg/cmd/ssh_alicloud.go
+++ b/pkg/cmd/ssh_alicloud.go
@@ -48,7 +48,6 @@ type AliyunInstanceAttribute struct {
 	InternetMaxBandwidthIn   string
 	InternetMaxBandwidthOut  string
 	IoOptimized              string
-	KeyPairName              string
 	PrivateIP                string
 	BastionIP                string
 	BastionSSHUser           string
@@ -156,7 +155,6 @@ func (a *AliyunInstanceAttribute) fetchAttributes(targetReader TargetReader, nod
 	a.InternetMaxBandwidthIn = "10"
 	a.InternetMaxBandwidthOut = "100"
 	a.IoOptimized = "optimized"
-	a.KeyPairName = a.ShootName + "-ssh-publickey"
 	a.InstanceType = a.getMinimumInstanceSpec()
 }
 


### PR DESCRIPTION
/kind cleanup

After https://github.com/gardener/gardenctl/pull/519, the `KeyPairName` is no longer used.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
