### PR TITLE
show error when failed to clean ops-pod

### DIFF
--- a/pkg/cmd/shell.go
+++ b/pkg/cmd/shell.go
@@ -177,6 +177,10 @@ func shellToNode(client kubernetes.Interface, targetKind TargetKind, nodeName st
 	}
 
 	err = client.CoreV1().Pods(namespace).Delete(podName, &metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Println("there are some errors while cleaning up the ops-pod, please manually clean it")
+		return err
+	}
 	return
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl/issues/522

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
