### PR TITLE
fix issue#526

### DIFF
--- a/pkg/cmd/aliyun.go
+++ b/pkg/cmd/aliyun.go
@@ -33,7 +33,7 @@ func NewAliyunCmd(targetReader TargetReader) *cobra.Command {
 				return errors.New("no shoot targeted")
 			}
 
-			arguments := "aliyun " + strings.Join(args[:], " ")
+			arguments := strings.Join(args[:], " ")
 			operate("aliyun", arguments)
 
 			return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to run aliyun cmd via gardenctl,  we need arguments after aliyun key word and pass to aliyun cli. but aliyun key word is duplicated in this case which causes error when running any aliyun cmd.

**Which issue(s) this PR fixes**:
Fixes #526 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
Fix bug in order to run aliyun cmd via gardenctl

Format of block header: <bugfix> <operator>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```