### PR TITLE
Create docforge manifest file

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,0 +1,9 @@
+{{- $vers := Split .versions "," -}}
+{{ $mainBranch := (index $vers 0) }}
+structure:
+- name: _index.md
+  source: https://github.com/gardener/gardenctl/blob/{{$mainBranch}}/README.md
+links:
+  downloads:
+    scope:
+      "gardener/gardenctl/(blob|raw)/(.*)/docs": ~

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # except those directories and files:
 !*.go
 !/.gitignore
+!/.docforge
+!/.docforge/manifest.yaml
 !/vendor
 !/hack/tools.go
 !/CODEOWNERS


### PR DESCRIPTION
**What this PR does / why we need it**:
Create docforge manifest file. In this way the gardenctl documentation will be exposed to the website

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
