### PR TITLE
Add check-docforge step in the check

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -46,3 +46,6 @@ fi
 
 echo "Running golangci-lint..."
 golangci-lint run ./...
+
+# Running check-docforge script
+${SOURCE_PATH}/hack/check-docforge.sh

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 !/.docforge/manifest.yaml
 !/vendor
 !/hack/tools.go
+!/hack/check-docforge.sh
 !/CODEOWNERS
 !/CONTRIBUTING.md
 !/Dockerfile

--- a/pkg/cmd/operate.go
+++ b/pkg/cmd/operate.go
@@ -205,7 +205,7 @@ func operate(provider, arguments string) string {
 			os.Exit(2)
 		}
 
-		if arguments == ""{
+		if arguments == "" {
 			return ""
 		}
 		args := strings.Fields(arguments)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -90,7 +90,7 @@ func Execute() {
 	pathGardenHome = os.Getenv("GARDENCTL_HOME")
 	if pathGardenHome == "" {
 		pathGardenHome = pathDefault
-	} else if strings.Contains(pathGardenHome, "~") {
+	} else {
 		pathGardenHome = strings.Replace(pathGardenHome, "~", HomeDir(), 1)
 	}
 	pathGardenConfig = filepath.Join(pathGardenHome, "config")

--- a/pkg/cmd/utils_test.go
+++ b/pkg/cmd/utils_test.go
@@ -17,12 +17,13 @@ package cmd_test
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"strings"
+
 	. "github.com/gardener/gardenctl/pkg/cmd"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	yaml "gopkg.in/yaml.v2"
-	"os"
-	"strings"
 )
 
 var _ = Describe("Utils", func() {
@@ -44,6 +45,10 @@ var _ = Describe("Utils", func() {
 	target.Target = append(target.Target, tm)
 
 	file, err := os.OpenFile(pathTarget, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		panic(err)
+	}
+
 	content, err := yaml.Marshal(target)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add check-docforge step in the existing check step.
This PR also fixes some errors appeared after running `golangci-lint`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@neo-liang-sap 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A new check-docforge step is added in the existing check step
```
