### PR TITLE
fix gcloud command for shared VPC

### DIFF
--- a/pkg/cmd/ssh_gcp.go
+++ b/pkg/cmd/ssh_gcp.go
@@ -122,7 +122,7 @@ func (g *GCPInstanceAttribute) fetchGCPAttributes(targetReader TargetReader, nod
 func (g *GCPInstanceAttribute) createBastionHostFirewallRule() {
 	fmt.Println("Add ssh rule")
 	if net.ParseIP(g.MyPublicIP).To4() != nil {
-		arguments := fmt.Sprintf("compute firewall-rules create %s --network %s --allow tcp:22 --source-ranges=%s/32", g.FirewallRuleName, g.ShootName, g.MyPublicIP)
+		arguments := fmt.Sprintf("compute firewall-rules create %s --network %s --allow tcp:22 --source-ranges=%s/32", g.FirewallRuleName, g.VpcName, g.MyPublicIP)
 		fmt.Println(operate("gcp", arguments))
 	} else {
 		fmt.Println("IPv6 is currently not fully supported by gardenctl: " + g.MyPublicIP)


### PR DESCRIPTION
**What this PR does / why we need it**:

The gcp version of the ssh command uses the wrong fied to specify the VPC (network) for firewall creation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
